### PR TITLE
fix(admin): admin 콘솔 실 API 페이지 401 → /login 이탈 수정

### DIFF
--- a/apps/admin-web/src/api/client.ts
+++ b/apps/admin-web/src/api/client.ts
@@ -31,8 +31,8 @@ export const apiClient = createApiClient({
   onUnauthorized: () => {
     tokenStorage.clearAll();
     const current = window.location.pathname;
-    if (!current.startsWith('/login')) {
-      window.location.href = '/login';
+    if (!current.startsWith('/admin/login')) {
+      window.location.href = '/admin/login';
     }
   },
 });

--- a/infra/nginx/academy.conf
+++ b/infra/nginx/academy.conf
@@ -76,9 +76,15 @@ server {
     }
 
     # Admin Backend API
-    #   /admin/api/xyz → :9001/api/admin/xyz
+    #   /admin/api/xyz → :9001/api/xyz
+    #
+    # 주의: 과거 /api/admin/ 로 rewrite 하던 설정은 legacy flat path(/api/member, /api/board 등)
+    # 와 매치되지 않아 전 기능 404/401 이었음. /api/ 로 바꾸면:
+    #   - legacy:  /admin/api/member/...  → /api/member/...          ✅
+    #   - new:     /admin/api/admin/menu  → /api/admin/menu          ✅
+    #   - auth·shared 는 위쪽 ^~ 블록이 먼저 매치되어 영향 없음
     location /admin/api/ {
-        proxy_pass http://host.docker.internal:9001/api/admin/;
+        proxy_pass http://host.docker.internal:9001/api/;
         include /etc/nginx/conf.d/proxy-params.conf;
         proxy_set_header X-Forwarded-Prefix /admin/api;
     }


### PR DESCRIPTION
## Summary

admin 콘솔에서 **회원관리 등 모든 실 API 호출 페이지**가 401 받고 user-web 로그인(/login)으로 이탈하던 문제 수정. 두 군데 버그 동시 해결.

## 원인

1. **nginx rewrite 불일치**: \`/admin/api/\` → \`/api/admin/\` rewrite 였는데, legacy flat path(\`/api/member\`, \`/api/board\` 등)는 \`/api/admin/\` prefix 없음 → 전부 경로 없는 요청
2. **admin onUnauthorized 경로 오류**: \`/login\`으로 리다이렉트해서 user-web 로그인 페이지로 이탈

## 변경

- \`infra/nginx/academy.conf\` — \`/admin/api/\` → \`/api/\` rewrite (legacy·신규 admin 모두 매치)
- \`apps/admin-web/src/api/client.ts\` — onUnauthorized → \`/admin/login\`

## Post-deploy 필요 작업

nginx bind-mount 를 다시 읽게 하려면 **게이트웨이 reload 수동 실행**:
\`\`\`bash
docker exec unmong-gateway nginx -s reload
\`\`\`

## Test plan

- [ ] ci-main 통과
- [ ] deploy 후 gateway reload → https://academy.unmong.com/admin/dashboard 에서 회원관리 클릭 → 401 이탈 없이 목록 로드
- [ ] 토큰 만료 시 \`/admin/login\` (not \`/login\`) 으로 리다이렉트