### PR TITLE
fix(nginx): X-Forwarded-Prefix 제거로 admin 실 API 401 해결

### DIFF
--- a/infra/nginx/academy.conf
+++ b/infra/nginx/academy.conf
@@ -17,6 +17,13 @@
 #     (/api/admin/**, /api/user/**, /api/shared/**)
 #   - admin-web(:4001) · user-web(:4002) 개별 컨테이너 (Vite 빌드)
 #   - Swagger UI / OpenAPI 는 무인증 공개, 실제 API 호출만 ADMIN/USER 역할 검증
+#
+# ⚠️ X-Forwarded-Prefix 금지:
+#   backend application.yml 의 server.forward-headers-strategy=framework 가
+#   ForwardedHeaderFilter 를 활성화해서 X-Forwarded-Prefix 를 contextPath 로 인식.
+#   이로 인해 Spring Security 의 path 매칭이 어긋나 보호 경로가 401 을 반환함
+#   (예: /admin/api/member/... → /api/member/... 로 rewrite 후 prefix 추가시 401).
+#   SPA 환경에서 backend 가 prefix 를 알 필요 없으므로 이 헤더는 일체 set 하지 않는다.
 # ============================================
 server {
     listen 443 ssl;
@@ -32,32 +39,26 @@ server {
     location ^~ /api/swagger-ui {
         proxy_pass http://host.docker.internal:9001/swagger-ui;
         include /etc/nginx/conf.d/proxy-params.conf;
-        proxy_set_header X-Forwarded-Prefix /api;
     }
     location ^~ /api/v3/api-docs {
         proxy_pass http://host.docker.internal:9001/v3/api-docs;
         include /etc/nginx/conf.d/proxy-params.conf;
-        proxy_set_header X-Forwarded-Prefix /api;
     }
     location ^~ /api/webjars {
         proxy_pass http://host.docker.internal:9001/webjars;
         include /etc/nginx/conf.d/proxy-params.conf;
-        proxy_set_header X-Forwarded-Prefix /api;
     }
     location ^~ /admin/api/swagger-ui {
         proxy_pass http://host.docker.internal:9001/swagger-ui;
         include /etc/nginx/conf.d/proxy-params.conf;
-        proxy_set_header X-Forwarded-Prefix /admin/api;
     }
     location ^~ /admin/api/v3/api-docs {
         proxy_pass http://host.docker.internal:9001/v3/api-docs;
         include /etc/nginx/conf.d/proxy-params.conf;
-        proxy_set_header X-Forwarded-Prefix /admin/api;
     }
     location ^~ /admin/api/webjars {
         proxy_pass http://host.docker.internal:9001/webjars;
         include /etc/nginx/conf.d/proxy-params.conf;
-        proxy_set_header X-Forwarded-Prefix /admin/api;
     }
 
     # Admin Auth — /api/auth/** 는 admin/user 공통 shared 엔드포인트이므로 /api/admin/ 로
@@ -65,28 +66,22 @@ server {
     location ^~ /admin/api/auth/ {
         proxy_pass http://host.docker.internal:9001/api/auth/;
         include /etc/nginx/conf.d/proxy-params.conf;
-        proxy_set_header X-Forwarded-Prefix /admin/api;
     }
 
     # Admin Shared API — 공통 /api/shared/**
     location ^~ /admin/api/shared/ {
         proxy_pass http://host.docker.internal:9001/api/shared/;
         include /etc/nginx/conf.d/proxy-params.conf;
-        proxy_set_header X-Forwarded-Prefix /admin/api;
     }
 
     # Admin Backend API
     #   /admin/api/xyz → :9001/api/xyz
     #
-    # 주의: 과거 /api/admin/ 로 rewrite 하던 설정은 legacy flat path(/api/member, /api/board 등)
-    # 와 매치되지 않아 전 기능 404/401 이었음. /api/ 로 바꾸면:
-    #   - legacy:  /admin/api/member/...  → /api/member/...          ✅
-    #   - new:     /admin/api/admin/menu  → /api/admin/menu          ✅
-    #   - auth·shared 는 위쪽 ^~ 블록이 먼저 매치되어 영향 없음
-    location /admin/api/ {
+    # ^~ 로 plain prefix 가 regex location 에 가로채지지 않도록 명시.
+    # legacy flat path(/api/member, /api/board 등) 와 신규(/api/admin/menu) 둘 다 매치.
+    location ^~ /admin/api/ {
         proxy_pass http://host.docker.internal:9001/api/;
         include /etc/nginx/conf.d/proxy-params.conf;
-        proxy_set_header X-Forwarded-Prefix /admin/api;
     }
 
     # Admin Frontend — trailing slash 로 /admin/ prefix strip.
@@ -103,7 +98,6 @@ server {
     location /api/ {
         proxy_pass http://host.docker.internal:9001/api/user/;
         include /etc/nginx/conf.d/proxy-params.conf;
-        proxy_set_header X-Forwarded-Prefix /api;
     }
 
     # User Frontend (default)


### PR DESCRIPTION
## Summary

\`/admin/dashboard\` 에서 회원관리 클릭 → 화면 깜빡 후 \`/admin/login\` 이탈하던 문제 수정.

## 원인

backend \`server.forward-headers-strategy=framework\` + nginx \`X-Forwarded-Prefix: /admin/api\` 조합으로 Spring Security path 매칭이 어긋나 보호 경로 401 반환.

로컬 sniffer 로 캡처해 backend 직접 호출에 동일 헤더 추가 → 401 재현 성공.

## 변경

\`infra/nginx/academy.conf\`:
- 모든 location 의 \`proxy_set_header X-Forwarded-Prefix\` 제거
- \`location /admin/api/\` → \`^~\` 명시

## Post-deploy

\`docker restart unmong-gateway\` 수동 실행 필요 (Mac Docker 단일 파일 mount inode 갱신).

## Test plan

- [ ] ci-main 통과
- [ ] deploy + gateway restart 후 admin/dashboard → 회원관리 → 목록 로드
- [ ] swagger UI · auth/me · /api/admin/menu 정상 동작 (회귀 없음)