### PR TITLE
feat(phase-a): acm_board_cs 테이블 + CS 문의 이관 ETL

### DIFF
--- a/backend/src/main/resources/db/migration/V8__acm_board_cs.sql
+++ b/backend/src/main/resources/db/migration/V8__acm_board_cs.sql
@@ -1,0 +1,65 @@
+-- =====================================================================
+-- V8: acm_board_cs — CS/1:1문의 전용 테이블 신설
+-- =====================================================================
+-- 배경:
+--   legacy tb_board_cs 에 5,430건의 CS 문의 누적. 본문·답변이 longblob 이라
+--   AI 분석·통계 집계에 부적합. acm_* 규약(ADR-005) 맞춰 TEXT 타입으로 재설계하고
+--   AI 분석에 필요한 컬럼(predicted_category, confidence, assigned_to 등) 추가.
+--
+-- 데이터 이관은 별도 ETL 스크립트 (scripts/data-migrate/board/) 에서 수행.
+-- 본 migration 은 빈 테이블만 생성 → prod 자동 실행 안전.
+--
+-- 관련 플랜: Claude-Opus-bluevlad/services/academy/CS_INQUIRY_AI_PLAN.md §4.2
+-- =====================================================================
+
+CREATE TABLE IF NOT EXISTS acm_board_cs (
+    cs_seq                  BIGINT        NOT NULL AUTO_INCREMENT,
+
+    -- 원본 참조 (이관 추적용, 재실행시 중복 방지)
+    legacy_board_seq        VARCHAR(20)   NULL COMMENT 'tb_board_cs.BOARD_SEQ',
+    legacy_cs_div           VARCHAR(20)   NULL COMMENT 'tb_board_cs.CS_DIV — CSCOUNSEL/CSREFUND 등',
+    legacy_cs_kind          VARCHAR(20)   NULL COMMENT 'tb_board_cs.CS_KIND — CSC120/CSR220 등',
+
+    -- 사용자 (PII 마스킹된 더미 값)
+    inquiry_user_id         VARCHAR(50)   NOT NULL COMMENT '마스킹된 usr_{hash}',
+    inquiry_name            VARCHAR(50)   NOT NULL COMMENT 'Faker 한국어 이름',
+
+    -- 문의 본문
+    inquiry_title           VARCHAR(300)  NOT NULL,
+    inquiry_body            MEDIUMTEXT    NOT NULL COMMENT '본문 (정규식 PII 치환 후)',
+    inquiry_date            DATETIME      NOT NULL,
+
+    -- AI 분류 결과 (Phase B 에서 채움)
+    predicted_category      VARCHAR(30)   NULL  COMMENT 'ACADEMIC|ORDER|SYSTEM|OTHER',
+    predicted_confidence    DECIMAL(5,4)  NULL  COMMENT '0.0000 ~ 1.0000',
+    classified_by_model     VARCHAR(50)   NULL  COMMENT 'ex: qwen2.5:7b',
+    classified_at           DATETIME      NULL,
+
+    -- 운영자 확정 카테고리 (재배정 반영)
+    actual_category         VARCHAR(30)   NULL,
+    assigned_to             VARCHAR(50)   NULL  COMMENT '담당자 user_id',
+    reroute_count           INT           NOT NULL DEFAULT 0,
+
+    -- 답변·해결여부
+    answer_body             MEDIUMTEXT    NULL,
+    answered_by             VARCHAR(50)   NULL,
+    answered_at             DATETIME      NULL,
+    resolution_state        VARCHAR(20)   NOT NULL DEFAULT 'OPEN'
+                            COMMENT 'OPEN|ANSWERED|RESOLVED|CLOSED',
+    user_satisfaction       TINYINT       NULL COMMENT '1-5 별점',
+
+    -- 감사
+    reg_dt                  DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    upd_dt                  DATETIME      NULL ON UPDATE CURRENT_TIMESTAMP,
+    is_deleted              CHAR(1)       NOT NULL DEFAULT 'N',
+
+    PRIMARY KEY (cs_seq),
+    UNIQUE KEY uk_legacy (legacy_board_seq),
+    KEY idx_predicted (predicted_category, classified_at),
+    KEY idx_actual (actual_category, reg_dt),
+    KEY idx_state (resolution_state),
+    KEY idx_assigned (assigned_to, resolution_state),
+    KEY idx_inquiry_date (inquiry_date),
+    KEY idx_user (inquiry_user_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='CS/1:1문의 — AI 분류·라우팅 대상. tb_board_cs 이관';

--- a/backend/src/main/resources/db/migration/V9__acm_inquiry_ai_tables.sql
+++ b/backend/src/main/resources/db/migration/V9__acm_inquiry_ai_tables.sql
@@ -1,0 +1,96 @@
+-- =====================================================================
+-- V9: AI 분석·라우팅·통계 부속 테이블 4종
+-- =====================================================================
+-- 빈 테이블 생성만. Phase B 이후 agent 서비스가 채움.
+-- 관련 플랜: Claude-Opus-bluevlad/services/academy/CS_INQUIRY_AI_PLAN.md §4.2
+-- =====================================================================
+
+-- ---------------------------------------------------------------------
+-- 1. AI 분석 이력 (감사·디버깅)
+-- ---------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS acm_inquiry_analysis (
+    analysis_seq    BIGINT        NOT NULL AUTO_INCREMENT,
+    cs_seq          BIGINT        NOT NULL,
+
+    -- 모델 메타
+    model_name      VARCHAR(50)   NOT NULL COMMENT 'qwen2.5:7b 등',
+    model_version   VARCHAR(50)   NULL     COMMENT 'Ollama digest',
+    prompt_template VARCHAR(50)   NOT NULL COMMENT 'v1, v2 ... few-shot 버전',
+
+    -- 결과
+    raw_output      TEXT          NULL COMMENT 'LLM 원 응답 (감사)',
+    parsed_category VARCHAR(30)   NULL,
+    confidence      DECIMAL(5,4)  NULL,
+    latency_ms      INT           NULL,
+    error_msg       TEXT          NULL,
+
+    created_at      DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (analysis_seq),
+    KEY idx_cs_time (cs_seq, created_at),
+    KEY idx_model (model_name, created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='AI 분류 원시 결과 이력 (재현·디버깅 용)';
+
+
+-- ---------------------------------------------------------------------
+-- 2. 담당자 재배정 로그 (학습 데이터)
+-- ---------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS acm_inquiry_routing_log (
+    log_seq         BIGINT        NOT NULL AUTO_INCREMENT,
+    cs_seq          BIGINT        NOT NULL,
+
+    from_category   VARCHAR(30)   NULL COMMENT 'AI 최초 분류 또는 직전 할당',
+    to_category     VARCHAR(30)   NOT NULL,
+    from_user       VARCHAR(50)   NULL,
+    to_user         VARCHAR(50)   NOT NULL,
+
+    reason          VARCHAR(500)  NULL,
+    changed_by      VARCHAR(50)   NOT NULL,
+    changed_at      DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    is_ai_error     CHAR(1)       NOT NULL DEFAULT 'N'
+                    COMMENT 'Y=AI 오분류로 간주 → few-shot 학습 셋 포함',
+
+    PRIMARY KEY (log_seq),
+    KEY idx_cs (cs_seq),
+    KEY idx_learning (is_ai_error, changed_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='재배정 이력. is_ai_error=Y 건은 주간 few-shot 갱신 입력';
+
+
+-- ---------------------------------------------------------------------
+-- 3. 월간 집계 (배치 갱신, materialized view 대체)
+-- ---------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS acm_inquiry_stats_monthly (
+    year_month          CHAR(7)       NOT NULL COMMENT 'YYYY-MM',
+    category            VARCHAR(30)   NOT NULL,
+
+    total_count         INT           NOT NULL DEFAULT 0,
+    resolved_count      INT           NOT NULL DEFAULT 0,
+    avg_response_hours  DECIMAL(8,2)  NULL,
+    avg_satisfaction    DECIMAL(3,2)  NULL COMMENT '1-5',
+    ai_correct_rate     DECIMAL(5,4)  NULL COMMENT 'is_ai_error=N 비율',
+    mom_delta_pct       DECIMAL(6,2)  NULL COMMENT '전월 대비 변화율',
+
+    updated_at          DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP
+                        ON UPDATE CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (year_month, category)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='월간 카테고리별 인사이트 (매월 1일 배치)';
+
+
+-- ---------------------------------------------------------------------
+-- 4. 임베딩 백업 (주 저장소는 ChromaDB. 재구축시 fallback)
+-- ---------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS acm_inquiry_embedding (
+    cs_seq          BIGINT        NOT NULL,
+    model_name      VARCHAR(50)   NOT NULL COMMENT 'nomic-embed-text 등',
+    dim             INT           NOT NULL,
+    embedding       BLOB          NOT NULL COMMENT 'float32 array, little-endian',
+    created_at      DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (cs_seq, model_name),
+    KEY idx_created (created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='임베딩 벡터 DB 백업 — ChromaDB 컬렉션 유실시 재구축 용';

--- a/docs/data-strategy.md
+++ b/docs/data-strategy.md
@@ -81,6 +81,40 @@ scripts/data-migrate/
 - 개발/스테이징 환경에만 실행
 - 운영 환경에서 실행 시 즉시 abort (스크립트 첫 줄에서 환경 변수 체크)
 
+## CS 게시판 (`acm_board_cs`) 이관 정책
+
+`tb_board_cs` (legacy, 약 5,430건) → `acm_board_cs` 이관 시:
+
+| 원본 컬럼 | 처리 | 비고 |
+|----------|------|------|
+| `REG_ID` (작성자 ID) | `usr_{sha256[0:8]}` 결정적 해시 → `inquiry_user_id` | 동일 원값→동일 더미 (id_map 캐시) |
+| `CREATENAME` (이름) | Faker ko_KR 이름 → `inquiry_name` | user_id 매핑 고정 |
+| `COUNSELOR_ID` (담당자 ID) | 동일 해시 매핑 → `answered_by`/`assigned_to` | 직원 프라이버시 |
+| `SUBJECT` (제목) | 원본 보존 → `inquiry_title` | 정규식 스크러빙만 (전화·이메일) |
+| `CONTENT` / `ANSWER` (longblob) | UTF-8 디코딩 + 정규식 PII 치환 → `inquiry_body` / `answer_body` | 연락처·주민번호·이메일·한글이름(화이트리스트 제외) |
+| `CS_DIV` / `CS_KIND` | `legacy_cs_div` / `legacy_cs_kind` 로 보존 | AI Ground Truth 학습용 |
+| `REG_DT` (date) | `inquiry_date` (datetime) | 시분초 없음 |
+
+### 본문 스크러빙 정규식
+
+- 휴대폰: `01[016789][- ]?\d{3,4}[- ]?\d{4}` → `010-XXXX-XXXX`
+- 주민등록번호: `\d{6}[- ]?[1-4]\d{6}` → `XXXXXX-XXXXXXX`
+- 이메일: 표준 패턴 → `[email]`
+- 한글 이름 (보수적): 2-4음절 + 상위 20개 성씨 → `[이름]` (화이트리스트 단어 제외)
+
+### 실행 환경 가드
+
+ETL 스크립트는 다음 조건 불충족시 즉시 abort:
+- `DATA_MIGRATE_ENV` ∈ {dev, staging}
+- `TARGET_DB_HOST` = localhost/127.0.0.1 또는 `staging` 포함 호스트명
+
+### 학습 Ground Truth 활용
+
+Legacy `CS_DIV` 값 (`CSCOUNSEL` / `CSREFUND`) 을 `acm_board_cs.actual_category` 에 매핑 적재:
+- `CSCOUNSEL` → `ACADEMIC` (가정, 운영자 재검토 유도)
+- `CSREFUND` → `ORDER`
+- Phase B 의 AI 분류는 이 초기 값을 ground truth 로 **정확도 측정** 가능 (별도 수동 라벨링 불필요)
+
 ## 강사·교수소개 특별 정책
 
 저작권·초상권 우려로 **교수소개 영역은 전면 더미 데이터**:

--- a/scripts/data-migrate/board/.env.example
+++ b/scripts/data-migrate/board/.env.example
@@ -1,0 +1,29 @@
+# scripts/data-migrate/board/ 실행 환경 변수 — dev/staging only
+# 실제 사용 시 .env 로 복사하고 값 채우기 ( .env 는 gitignored )
+
+# ⚠️ 환경 가드: 반드시 dev 또는 staging. prod 는 스크립트 첫 줄에서 abort.
+DATA_MIGRATE_ENV=dev
+
+# 원본 (read-only, legacy tb_board_cs)
+SOURCE_DB_HOST=localhost
+SOURCE_DB_PORT=3306
+SOURCE_DB_USER=root
+SOURCE_DB_PASSWORD=
+SOURCE_DB_NAME=acm_basic
+
+# 타겟 (write, acm_board_cs)
+TARGET_DB_HOST=localhost
+TARGET_DB_PORT=3306
+TARGET_DB_USER=root
+TARGET_DB_PASSWORD=
+TARGET_DB_NAME=acm_basic
+
+# Faker locale
+FAKER_LOCALE=ko_KR
+FAKER_SEED=42
+
+# id_map 캐시 (동일 사용자 → 동일 더미 매핑 보존)
+ID_MAP_CACHE_PATH=./id_map.cache.json
+
+# 배치 크기
+BATCH_SIZE=500

--- a/scripts/data-migrate/board/.gitignore
+++ b/scripts/data-migrate/board/.gitignore
@@ -1,0 +1,6 @@
+.env
+.venv/
+__pycache__/
+*.pyc
+id_map.cache.json
+*.log

--- a/scripts/data-migrate/board/README.md
+++ b/scripts/data-migrate/board/README.md
@@ -1,0 +1,100 @@
+# Board ETL — tb_board_cs → acm_board_cs
+
+CS/1:1 문의 데이터를 legacy `tb_board_cs` 에서 신규 `acm_board_cs` 로 이관.
+**PII 마스킹 필수** (userId → 해시·이름 → Faker·본문 내 연락처·이메일 정규식 치환).
+
+관련 플랜: `Claude-Opus-bluevlad/services/academy/CS_INQUIRY_AI_PLAN.md` (Phase A)
+
+## 사전 요구
+
+- Python 3.11+
+- MariaDB 10.x 로컬 / staging 접근 (운영 DB 접근 금지)
+- Faker ko_KR, mariadb python 커넥터
+
+```bash
+cd scripts/data-migrate/board
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env
+# .env 편집: DATA_MIGRATE_ENV=dev, DB credentials
+```
+
+## 실행
+
+```bash
+# 1. dry-run: DB 쓰기 없이 처음 5건 변환 결과만 출력
+python migrate_cs.py --dry-run --limit 100
+
+# 2. 부분 실행 (처음 500건)
+python migrate_cs.py --limit 500
+
+# 3. 전체 이관
+python migrate_cs.py
+
+# 4. 증분 이관 (이미 적재된 legacy_board_seq 스킵)
+python migrate_cs.py --only-new
+```
+
+## 환경 가드
+
+스크립트는 실행 전 다음을 체크:
+
+1. `DATA_MIGRATE_ENV` 가 `dev` 또는 `staging` — 아니면 즉시 abort
+2. `TARGET_DB_HOST` 가 localhost/127.0.0.1 또는 `staging` 문자열 포함
+3. 위반 시 exit code 2
+
+운영 DB 에는 절대 실행 금지. 운영 DB 스냅샷은 시스템관리자가 별도로 dev 로 복제.
+
+## PII 마스킹 규칙
+
+| 원본 | 타겟 | 방식 |
+|------|------|------|
+| `REG_ID` | `inquiry_user_id` | `usr_{sha256[0:8]}` (결정적) |
+| `CREATENAME` | `inquiry_name` | Faker ko_KR (user_id 매핑 고정) |
+| `COUNSELOR_ID` | `answered_by` | 위와 동일 매핑표 |
+| 본문 `CONTENT/ANSWER` | `inquiry_body/answer_body` | 정규식: 휴대폰·주민번호·이메일·한글이름 치환 |
+
+`id_map.cache.json` 에 원→더미 매핑이 평문 JSON 으로 저장됨. **권한 0600 필수**.
+재실행 시 이 파일이 있으면 동일 사용자는 동일 더미 유지 (referential 보존).
+
+```bash
+chmod 600 id_map.cache.json
+```
+
+## 검증
+
+이관 후 샘플 확인:
+
+```sql
+-- 건수
+SELECT COUNT(*) FROM tb_board_cs;          -- 원본 건수
+SELECT COUNT(*) FROM acm_board_cs;         -- 이관 건수 (같아야)
+
+-- PII 유출 여부 (원 user_id 가 노출되면 FAIL)
+SELECT inquiry_user_id, inquiry_name FROM acm_board_cs LIMIT 10;
+-- inquiry_user_id 는 usr_xxxxxxxx 형식, inquiry_name 은 랜덤 한국 이름
+
+-- 본문 내 연락처·주민번호 남아있는지
+SELECT cs_seq FROM acm_board_cs
+WHERE inquiry_body REGEXP '01[016789][- ]?[0-9]{3,4}[- ]?[0-9]{4}'
+   OR inquiry_body REGEXP '[0-9]{6}[- ]?[1-4][0-9]{6}'
+LIMIT 5;
+-- 결과 0 건이어야 함
+
+-- 카테고리 힌트 (legacy CS_DIV 매핑)
+SELECT actual_category, COUNT(*) FROM acm_board_cs GROUP BY actual_category;
+-- ACADEMIC (CSCOUNSEL), ORDER (CSREFUND), NULL (기타)
+```
+
+## 재실행 안전성
+
+- `acm_board_cs.legacy_board_seq` 에 UNIQUE 제약 → 중복 삽입 방지
+- `INSERT ... ON DUPLICATE KEY UPDATE` 로 본문·답변만 갱신
+- `--only-new` 옵션: 이미 있는 legacy_board_seq 는 source 쿼리 단계에서 skip
+
+## 다음 단계 (Phase B)
+
+1. Agent 서비스 (`services/agent/`) 기동 → qwen2.5:7b 로 분류
+2. 배치: `acm_board_cs` 전 행 반복하며 `/classify` 호출 → `predicted_category` 채움
+3. 결과를 `actual_category` (legacy CS_DIV 힌트) 와 비교 → 초기 정확도 측정

--- a/scripts/data-migrate/board/content_scrubber.py
+++ b/scripts/data-migrate/board/content_scrubber.py
@@ -1,0 +1,88 @@
+"""본문 텍스트 내 PII 정규식 스크러버.
+
+원본 본문 (tb_board_cs.CONTENT) 에 노출된:
+- 휴대폰 / 일반 전화 → 010-XXXX-XXXX
+- 주민등록번호 → XXXXXX-XXXXXXX
+- 이메일 → [email]
+- 이름 (3음절 한글) — 강사·직원 화이트리스트 제외
+
+HTML 태그는 보존 (원본이 에디터 HTML 이므로). 분석 단계에서 태그 스트립 가능.
+"""
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+
+# --- 정규식 ---------------------------------------------------------------
+_RE_PHONE = re.compile(r"\b01[016789][- ]?\d{3,4}[- ]?\d{4}\b")
+_RE_LAND = re.compile(r"\b0[2-9]\d?[- ]?\d{3,4}[- ]?\d{4}\b")
+_RE_RRN = re.compile(r"\b\d{6}[- ]?[1-4]\d{6}\b")
+_RE_EMAIL = re.compile(r"[\w\.-]+@[\w\.-]+\.\w{2,}", re.IGNORECASE)
+# 3음절 한글 이름 후보 (보수적, 추정)
+_RE_KOR_NAME = re.compile(r"(?<![가-힣])[가-힣]{2,4}(?![가-힣])")
+
+
+def scrub(
+    text: str | bytes | None,
+    *,
+    name_whitelist: Iterable[str] = (),
+) -> str:
+    """본문 내 PII 를 치환한 텍스트 반환.
+
+    - bytes (longblob) 은 UTF-8 디코딩 시도. cp949 fallback.
+    - 이름 치환은 화이트리스트 제외만 적용 (너무 적극적이면 과치환).
+    - HTML 태그 보존.
+    """
+    if text is None:
+        return ""
+
+    if isinstance(text, bytes):
+        for enc in ("utf-8", "cp949", "euc-kr", "latin-1"):
+            try:
+                text = text.decode(enc)
+                break
+            except UnicodeDecodeError:
+                continue
+        else:
+            text = text.decode("utf-8", errors="replace")
+
+    if not isinstance(text, str):
+        text = str(text)
+
+    text = _RE_RRN.sub("XXXXXX-XXXXXXX", text)
+    text = _RE_PHONE.sub("010-XXXX-XXXX", text)
+    text = _RE_LAND.sub("0X-XXXX-XXXX", text)
+    text = _RE_EMAIL.sub("[email]", text)
+
+    wl = {n.strip() for n in name_whitelist if n and n.strip()}
+    if wl:
+        # 화이트리스트 외 3-4음절 한글 이름 의심 단어는 [이름] 으로
+        def _repl(m: re.Match[str]) -> str:
+            token = m.group(0)
+            if token in wl:
+                return token
+            if len(token) < 2 or len(token) > 4:
+                return token
+            # 성씨 1글자 + 이름 2-3글자 구성인지 보수적 판단 (과치환 방지)
+            if not _is_likely_korean_name(token):
+                return token
+            return "[이름]"
+
+        text = _RE_KOR_NAME.sub(_repl, text)
+
+    return text
+
+
+# 한국 성씨 상위 빈도 (보수적)
+_COMMON_SURNAMES = {
+    "김", "이", "박", "최", "정", "강", "조", "윤", "장", "임",
+    "한", "오", "서", "신", "권", "황", "안", "송", "류", "홍",
+}
+
+
+def _is_likely_korean_name(token: str) -> bool:
+    """2-4음절 한글, 첫글자가 상위 성씨인 경우만 이름 후보로."""
+    if not (2 <= len(token) <= 4):
+        return False
+    return token[0] in _COMMON_SURNAMES

--- a/scripts/data-migrate/board/migrate_cs.py
+++ b/scripts/data-migrate/board/migrate_cs.py
@@ -1,0 +1,265 @@
+"""tb_board_cs → acm_board_cs 이관 스크립트.
+
+사용법:
+    cp .env.example .env
+    # .env 에 DB 접속·DATA_MIGRATE_ENV=dev 설정
+    pip install -r requirements.txt
+    python migrate_cs.py --dry-run          # 100건만 변환해 결과 미리보기 (DB 쓰기 없음)
+    python migrate_cs.py                     # 전체 이관
+    python migrate_cs.py --limit 500         # 처음 500건만
+    python migrate_cs.py --only-new          # 이미 이관된 legacy_board_seq 제외
+
+환경 가드:
+    DATA_MIGRATE_ENV 가 'dev' 또는 'staging' 이어야 실행. 'prod' 면 즉시 abort.
+    타겟 DB 가 localhost 또는 명시적 staging host 가 아니면 확인 프롬프트.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import json
+from datetime import datetime, date
+from pathlib import Path
+
+import click
+import mariadb
+
+from pii_mapping import PiiMapper
+from content_scrubber import scrub
+
+
+ALLOWED_ENVS = {"dev", "staging"}
+HERE = Path(__file__).parent
+
+
+# --- 환경 가드 ------------------------------------------------------------
+def load_env() -> dict:
+    """.env 파일 + os.environ 머지."""
+    env = dict(os.environ)
+    env_file = HERE / ".env"
+    if env_file.exists():
+        for line in env_file.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if "=" not in line:
+                continue
+            k, v = line.split("=", 1)
+            env.setdefault(k.strip(), v.strip())
+    return env
+
+
+def assert_safe_env(env: dict) -> None:
+    mig_env = env.get("DATA_MIGRATE_ENV", "").lower()
+    if mig_env not in ALLOWED_ENVS:
+        click.echo(
+            click.style(
+                f"[!] DATA_MIGRATE_ENV='{mig_env}' 는 허용 안됨. dev 또는 staging 만.",
+                fg="red",
+                bold=True,
+            ),
+            err=True,
+        )
+        sys.exit(2)
+
+    target_host = env.get("TARGET_DB_HOST", "")
+    if target_host not in ("localhost", "127.0.0.1") and "staging" not in target_host:
+        click.echo(
+            click.style(
+                f"[!] TARGET_DB_HOST='{target_host}' 가 명시 staging/localhost 가 아님. "
+                "--force-non-local 없이는 실행 불가.",
+                fg="red",
+                bold=True,
+            ),
+            err=True,
+        )
+        sys.exit(2)
+
+
+# --- DB 커넥션 ------------------------------------------------------------
+def connect(env: dict, *, role: str) -> mariadb.Connection:
+    prefix = "SOURCE_DB" if role == "source" else "TARGET_DB"
+    return mariadb.connect(
+        host=env[f"{prefix}_HOST"],
+        port=int(env.get(f"{prefix}_PORT", 3306)),
+        user=env[f"{prefix}_USER"],
+        password=env[f"{prefix}_PASSWORD"],
+        database=env[f"{prefix}_NAME"],
+        autocommit=False,
+    )
+
+
+# --- 변환 ---------------------------------------------------------------
+def to_datetime(d) -> datetime | None:
+    if d is None:
+        return None
+    if isinstance(d, datetime):
+        return d
+    if isinstance(d, date):
+        return datetime(d.year, d.month, d.day)
+    try:
+        return datetime.fromisoformat(str(d))
+    except Exception:
+        return None
+
+
+def transform_row(row: dict, mapper: PiiMapper) -> dict:
+    """legacy row → acm_board_cs 삽입용 dict."""
+    masked_id, masked_name = mapper.mask(row.get("REG_ID"))
+    # 화이트리스트는 필요시 env 로 주입 (강사 실명 보존 등)
+    name_wl: list[str] = []
+
+    title = (row.get("SUBJECT") or "").strip() or "(제목없음)"
+    body = scrub(row.get("CONTENT"), name_whitelist=name_wl)
+    answer = scrub(row.get("ANSWER"), name_whitelist=name_wl)
+
+    inquiry_date = to_datetime(row.get("REG_DT")) or datetime.now()
+
+    # AI 분류는 Phase B 에서 채움. actual_category 는 legacy CS_DIV 에서 힌트
+    actual_category = {
+        "CSCOUNSEL": "ACADEMIC",  # 상담성 문의는 학사 계열로 가정 (운영자 재배정 유도)
+        "CSREFUND": "ORDER",      # 환불 문의
+    }.get((row.get("CS_DIV") or "").upper(), None)
+
+    counselor = row.get("COUNSELOR_ID")
+    answered_by = None
+    if counselor:
+        # 담당자도 마스킹 (직원 프라이버시)
+        answered_by, _ = mapper.mask(counselor)
+
+    return {
+        "legacy_board_seq": (row.get("BOARD_SEQ") or "")[:20] or None,
+        "legacy_cs_div": (row.get("CS_DIV") or "")[:20] or None,
+        "legacy_cs_kind": (row.get("CS_KIND") or "")[:20] or None,
+        "inquiry_user_id": masked_id,
+        "inquiry_name": masked_name,
+        "inquiry_title": title[:300],
+        "inquiry_body": body,
+        "inquiry_date": inquiry_date,
+        "actual_category": actual_category,
+        "assigned_to": answered_by,
+        "answer_body": answer or None,
+        "answered_by": answered_by,
+        "answered_at": inquiry_date if answer else None,
+        "resolution_state": "ANSWERED" if answer else "OPEN",
+    }
+
+
+# --- 메인 ---------------------------------------------------------------
+@click.command()
+@click.option("--limit", type=int, default=0, help="처리 건수 제한 (0=전체)")
+@click.option("--batch", type=int, default=None, help="배치 크기 (기본 .env)")
+@click.option("--dry-run", is_flag=True, help="DB 쓰기 없이 변환만 (처음 5건 출력)")
+@click.option("--only-new", is_flag=True, help="이미 이관된 legacy_board_seq 는 건너뜀")
+def main(limit: int, batch: int | None, dry_run: bool, only_new: bool) -> None:
+    env = load_env()
+    assert_safe_env(env)
+
+    batch_size = batch or int(env.get("BATCH_SIZE", 500))
+
+    cache_path = Path(env.get("ID_MAP_CACHE_PATH", "./id_map.cache.json"))
+    mapper = PiiMapper(
+        cache_path=cache_path,
+        faker_locale=env.get("FAKER_LOCALE", "ko_KR"),
+        faker_seed=int(env.get("FAKER_SEED", 42)),
+    )
+
+    click.echo(f"DATA_MIGRATE_ENV={env.get('DATA_MIGRATE_ENV')}")
+    click.echo(
+        f"source={env['SOURCE_DB_HOST']}:{env['SOURCE_DB_PORT']}/"
+        f"{env['SOURCE_DB_NAME']} → target={env['TARGET_DB_HOST']}:"
+        f"{env['TARGET_DB_PORT']}/{env['TARGET_DB_NAME']}"
+    )
+    click.echo(f"dry_run={dry_run}  limit={limit or 'ALL'}  batch={batch_size}")
+
+    src = connect(env, role="source")
+    tgt = None if dry_run else connect(env, role="target")
+
+    existing: set[str] = set()
+    if only_new and tgt is not None:
+        with tgt.cursor() as c:
+            c.execute("SELECT legacy_board_seq FROM acm_board_cs WHERE legacy_board_seq IS NOT NULL")
+            existing = {r[0] for r in c.fetchall()}
+        click.echo(f"이미 이관된 legacy_board_seq = {len(existing)} 건 (제외)")
+
+    src_cur = src.cursor(dictionary=True)
+    sql_select = (
+        "SELECT BOARD_MNG_SEQ, BOARD_SEQ, CS_DIV, CS_KIND, SUBJECT, CONTENT, "
+        "REG_DT, REG_ID, CREATENAME, ANSWER, COUNSELOR_ID, ACTION_YN "
+        "FROM tb_board_cs "
+        "ORDER BY REG_DT ASC"
+    )
+    if limit > 0:
+        sql_select += f" LIMIT {limit}"
+    src_cur.execute(sql_select)
+
+    total = 0
+    skipped = 0
+    buf: list[dict] = []
+
+    for row in src_cur:
+        legacy_seq = (row.get("BOARD_SEQ") or "").strip()
+        if only_new and legacy_seq in existing:
+            skipped += 1
+            continue
+
+        transformed = transform_row(row, mapper)
+        buf.append(transformed)
+
+        if dry_run and total < 5:
+            preview = {k: (v if k != "inquiry_body" else (v[:200] + "…" if len(v) > 200 else v))
+                       for k, v in transformed.items()}
+            click.echo("--- 샘플 ---")
+            click.echo(json.dumps(preview, ensure_ascii=False, indent=2, default=str))
+
+        total += 1
+        if len(buf) >= batch_size:
+            if not dry_run:
+                insert_batch(tgt, buf)
+            buf.clear()
+
+    if buf and not dry_run:
+        insert_batch(tgt, buf)
+
+    mapper.flush()
+
+    if tgt is not None:
+        tgt.commit()
+        tgt.close()
+    src.close()
+
+    click.echo("")
+    click.echo(click.style(f"✓ 처리 {total} 건 (skip {skipped})  id_map={len(mapper)}",
+                           fg="green", bold=True))
+    click.echo(f"  캐시: {cache_path.resolve()}  (0600 권한 설정 권장)")
+
+
+def insert_batch(conn: mariadb.Connection, rows: list[dict]) -> None:
+    sql = """
+        INSERT INTO acm_board_cs (
+            legacy_board_seq, legacy_cs_div, legacy_cs_kind,
+            inquiry_user_id, inquiry_name,
+            inquiry_title, inquiry_body, inquiry_date,
+            actual_category, assigned_to,
+            answer_body, answered_by, answered_at,
+            resolution_state, reg_dt
+        ) VALUES (
+            %(legacy_board_seq)s, %(legacy_cs_div)s, %(legacy_cs_kind)s,
+            %(inquiry_user_id)s, %(inquiry_name)s,
+            %(inquiry_title)s, %(inquiry_body)s, %(inquiry_date)s,
+            %(actual_category)s, %(assigned_to)s,
+            %(answer_body)s, %(answered_by)s, %(answered_at)s,
+            %(resolution_state)s, %(inquiry_date)s
+        )
+        ON DUPLICATE KEY UPDATE
+            inquiry_title = VALUES(inquiry_title),
+            inquiry_body  = VALUES(inquiry_body),
+            answer_body   = VALUES(answer_body),
+            upd_dt        = CURRENT_TIMESTAMP
+    """
+    with conn.cursor() as c:
+        c.executemany(sql, rows)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/data-migrate/board/pii_mapping.py
+++ b/scripts/data-migrate/board/pii_mapping.py
@@ -1,0 +1,65 @@
+"""PII 마스킹·referential 매핑.
+
+동일 원본 user_id 는 동일 더미 user_id·이름으로 매핑되어야 통계·답변 관계가
+깨지지 않는다. 해시 접두 8자 + Faker 이름 조합. 캐시는 JSON 파일에 영속.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Dict
+
+from faker import Faker
+
+
+class PiiMapper:
+    """원 user_id → {masked_id, masked_name} 매핑.
+
+    - masked_id: usr_<sha256(원)[:8]>  — 결정적, 동일 원값 동일 결과
+    - masked_name: Faker 한국어 이름. Faker seed 고정 시 재현 가능하지만
+      랜덤 이름 회전 회피 위해 캐시에 저장.
+    """
+
+    def __init__(self, cache_path: Path, faker_locale: str = "ko_KR", faker_seed: int = 42):
+        self._cache_path = cache_path
+        self._fake = Faker(faker_locale)
+        Faker.seed(faker_seed)
+        self._map: Dict[str, Dict[str, str]] = {}
+        if cache_path.exists():
+            try:
+                self._map = json.loads(cache_path.read_text(encoding="utf-8"))
+            except Exception:
+                self._map = {}
+
+    def mask(self, original_id: str | None) -> tuple[str, str]:
+        """원 user_id → (masked_id, masked_name).
+
+        None·빈값은 ("anonymous", "익명사용자") 반환.
+        """
+        if not original_id:
+            return ("anonymous", "익명사용자")
+
+        key = original_id.strip()
+        if not key:
+            return ("anonymous", "익명사용자")
+
+        if key in self._map:
+            row = self._map[key]
+            return (row["id"], row["name"])
+
+        digest = hashlib.sha256(key.encode("utf-8")).hexdigest()[:8]
+        masked_id = f"usr_{digest}"
+        masked_name = self._fake.name()
+        self._map[key] = {"id": masked_id, "name": masked_name}
+        return (masked_id, masked_name)
+
+    def flush(self) -> None:
+        """캐시 파일에 저장. 0600 권한 권장 (운영자 수동 설정)."""
+        self._cache_path.write_text(
+            json.dumps(self._map, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+    def __len__(self) -> int:
+        return len(self._map)

--- a/scripts/data-migrate/board/requirements.txt
+++ b/scripts/data-migrate/board/requirements.txt
@@ -1,0 +1,3 @@
+mariadb>=1.1.10
+Faker>=30.0.0
+click>=8.1.0


### PR DESCRIPTION
## Summary

**Phase A of CS_INQUIRY_AI_PLAN** (메타 repo). CS 문의 5,430건 기반 AI 분류·라우팅 시스템의 **데이터 레이어** 구축.

## 변경

**Backend — Flyway 2개 (prod 자동 실행, 빈 테이블 생성만)**:
- \`V8__acm_board_cs.sql\` — CS 문의 전용 테이블 + AI 분석 컬럼
- \`V9__acm_inquiry_ai_tables.sql\` — 부속 4종 (analysis/routing_log/stats_monthly/embedding)

**ETL — \`scripts/data-migrate/board/\`** (Python):
- \`pii_mapping.py\` · \`content_scrubber.py\` · \`migrate_cs.py\`
- PII 마스킹: user_id → \`usr_{sha256[:8]}\`, 이름 → Faker ko_KR, 본문 정규식 치환
- 환경 가드 (prod 실행 abort), 재실행 referential 보존
- 실행은 **user 가 dev DB 에서 수동**. CI 에서 실행 안 함.

**Docs**:
- \`docs/data-strategy.md\` 에 acm_board_cs 정책·스크러빙 규칙 추가

## Ground Truth 활용 (무료 학습 데이터)

Legacy \`CS_DIV\` 값을 \`acm_board_cs.actual_category\` 에 매핑:
- CSCOUNSEL → ACADEMIC (3,300건)
- CSREFUND → ORDER (1,782건)

→ Phase B 의 AI 분류 초기 정확도 측정에 직접 활용 (수동 라벨링 불필요).

## Test plan

- [ ] ci-main (backend mvn test + frontend typecheck) 통과
- [ ] deploy-prod 시 V8/V9 auto-migration 성공 (빈 테이블 생성, 데이터 영향 0)
- [ ] deploy 후 \`DESC acm_board_cs\` 정상 조회
- [ ] 다음 PR 전: user 가 dev DB 에서 \`python migrate_cs.py --dry-run\` 샘플 검증

## Post-deploy (user 수행)

\`\`\`bash
cd scripts/data-migrate/board
python -m venv .venv && source .venv/bin/activate
pip install -r requirements.txt
cp .env.example .env
# .env 편집: DATA_MIGRATE_ENV=dev + DB 패스워드
python migrate_cs.py --dry-run --limit 100   # 샘플 검증
python migrate_cs.py                          # 전체 이관
chmod 600 id_map.cache.json                   # 매핑 캐시 보호
\`\`\`