### PR TITLE
fix(agent): classifier prompt .format() 충돌 수정

### DIFF
--- a/services/agent/app/core/classifier.py
+++ b/services/agent/app/core/classifier.py
@@ -53,7 +53,12 @@ async def classify_inquiry(title: str, body: str) -> ClassifyResult:
     """
     # 본문 너무 길면 4000자로 절단 (한글 tokenizer 기준 약 2000 토큰)
     body_short = (body or "")[:4000]
-    prompt = PROMPT_TEMPLATE.format(title=title or "(제목없음)", body=body_short)
+    # .format() 은 프롬프트 내 JSON 예시의 {} 와 충돌 → 단순 replace 사용
+    prompt = (
+        PROMPT_TEMPLATE
+        .replace("{title}", title or "(제목없음)")
+        .replace("{body}", body_short)
+    )
 
     raw = ""
     latency = 0


### PR DESCRIPTION
Phase B agent 의 /classify 500 오류 hotfix. PROMPT_TEMPLATE.format() 이 JSON 예시의 {} 를 placeholder 로 해석 → KeyError. .replace() 로 변경.