### PR TITLE
feat(phase-c): 운영자 1:1 문의 응대 콘솔 + agent 연동

### DIFF
--- a/apps/admin-web/src/App.tsx
+++ b/apps/admin-web/src/App.tsx
@@ -7,6 +7,7 @@ import { MembersPage } from './pages/members/MembersPage';
 import { SubjectsPage } from './pages/subjects/SubjectsPage';
 import { LecturesPage } from './pages/lectures/LecturesPage';
 import { InstructorsPage } from './pages/instructors/InstructorsPage';
+import { InquiriesPage } from './pages/inquiries/InquiriesPage';
 import { OrdersPage } from './pages/orders/OrdersPage';
 import { CouponsPage } from './pages/coupons/CouponsPage';
 import { BooksPage } from './pages/books/BooksPage';
@@ -34,6 +35,7 @@ export function App() {
         <Route path="coupons" element={<CouponsPage />} />
         <Route path="books" element={<BooksPage />} />
         <Route path="mocktest" element={<MockExamsPage />} />
+        <Route path="support/inquiries" element={<InquiriesPage />} />
       </Route>
       <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>

--- a/apps/admin-web/src/api/inquiries.ts
+++ b/apps/admin-web/src/api/inquiries.ts
@@ -1,0 +1,97 @@
+/**
+ * CS 문의 운영자 콘솔 API. (CS_INQUIRY_AI_PLAN Phase C)
+ *
+ * backend /api/inquiries 와 academy-agent (로컬 Ollama) 연동.
+ * 신 ApiResponse envelope 사용 (unwrap).
+ */
+import { unwrap } from '@academy/ui-core';
+import type { ApiResponse, PagedResponse } from '@academy/ui-core';
+import { apiClient } from './client';
+
+export type InquiryCategory = 'ACADEMIC' | 'ORDER' | 'SYSTEM' | 'OTHER';
+export type ResolutionState = 'OPEN' | 'ANSWERED' | 'RESOLVED' | 'CLOSED';
+
+export interface Inquiry {
+  csSeq: number;
+  inquiryUserId: string;
+  inquiryName: string;
+  inquiryTitle: string;
+  bodyPreview?: string | null;
+  body?: string | null;
+  inquiryDate: string;
+  predictedCategory?: InquiryCategory | string | null;
+  predictedConfidence?: number | null;
+  classifiedByModel?: string | null;
+  classifiedAt?: string | null;
+  actualCategory?: InquiryCategory | string | null;
+  assignedTo?: string | null;
+  rerouteCount: number;
+  answerBody?: string | null;
+  answeredBy?: string | null;
+  answeredAt?: string | null;
+  resolutionState: ResolutionState | string;
+  userSatisfaction?: number | null;
+}
+
+export interface InquirySearch {
+  category?: '' | InquiryCategory;
+  resolutionState?: '' | ResolutionState;
+  keyword?: string;
+  assignedTo?: string;
+  page?: number;
+  size?: number;
+}
+
+export interface RelatedItem {
+  cs_seq: number;
+  title: string;
+  answer_excerpt?: string | null;
+  similarity: number;
+  category?: string | null;
+}
+
+export interface SuggestResponse {
+  items: RelatedItem[];
+  query_embedding_dim: number;
+  model: string;
+}
+
+export async function listInquiries(params: InquirySearch): Promise<PagedResponse<Inquiry>> {
+  const res = await apiClient.get<ApiResponse<PagedResponse<Inquiry>>>('/inquiries', { params });
+  return unwrap<PagedResponse<Inquiry>>({ data: res.data });
+}
+
+export async function getInquiryDetail(csSeq: number): Promise<Inquiry> {
+  const res = await apiClient.get<ApiResponse<Inquiry>>(`/inquiries/${csSeq}`);
+  return unwrap<Inquiry>({ data: res.data });
+}
+
+export async function classifyNow(csSeq: number): Promise<Inquiry> {
+  const res = await apiClient.post<ApiResponse<Inquiry>>(`/inquiries/${csSeq}/classify`);
+  return unwrap<Inquiry>({ data: res.data });
+}
+
+export async function postAnswer(
+  csSeq: number,
+  answerBody: string,
+  resolutionState?: ResolutionState,
+): Promise<Inquiry> {
+  const res = await apiClient.post<ApiResponse<Inquiry>>(`/inquiries/${csSeq}/answer`, {
+    answerBody,
+    resolutionState,
+  });
+  return unwrap<Inquiry>({ data: res.data });
+}
+
+export async function reassignInquiry(
+  csSeq: number,
+  payload: { toCategory: string; toUser: string; reason?: string; isAiError?: boolean },
+): Promise<Inquiry> {
+  const res = await apiClient.post<ApiResponse<Inquiry>>(`/inquiries/${csSeq}/reassign`, payload);
+  return unwrap<Inquiry>({ data: res.data });
+}
+
+export async function getRelated(csSeq: number): Promise<SuggestResponse> {
+  const res = await apiClient.get<ApiResponse<SuggestResponse>>(`/inquiries/${csSeq}/related`);
+  return unwrap<SuggestResponse>({ data: res.data });
+}

--- a/apps/admin-web/src/pages/AdminShell.tsx
+++ b/apps/admin-web/src/pages/AdminShell.tsx
@@ -14,6 +14,7 @@ import {
   FileTextOutlined,
   TeamOutlined,
   ApartmentOutlined,
+  CustomerServiceOutlined,
 } from '@ant-design/icons';
 
 const menuGroups: SidebarMenuGroup[] = [
@@ -40,6 +41,13 @@ const menuGroups: SidebarMenuGroup[] = [
       { key: 'subjects', icon: <ApartmentOutlined />, label: '과목관리', to: '/subjects' },
       { key: 'lectures', icon: <BookOutlined />, label: '강의관리', to: '/lectures' },
       { key: 'instructors', icon: <TeamOutlined />, label: '강사관리', to: '/instructors' },
+    ],
+  },
+  {
+    key: 'support',
+    label: '고객센터',
+    items: [
+      { key: 'inquiries', icon: <CustomerServiceOutlined />, label: '1:1 문의 응대', to: '/support/inquiries' },
     ],
   },
 ];

--- a/apps/admin-web/src/pages/inquiries/InquiriesPage.tsx
+++ b/apps/admin-web/src/pages/inquiries/InquiriesPage.tsx
@@ -1,0 +1,417 @@
+import { useMemo, useState } from 'react';
+import {
+  Alert,
+  Badge,
+  Button,
+  Descriptions,
+  Drawer,
+  Form,
+  Input,
+  Progress,
+  Select,
+  Space,
+  Table,
+  Tag,
+  message,
+} from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import { ReloadOutlined, SearchOutlined, ThunderboltOutlined } from '@ant-design/icons';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { PageContainer } from '@academy/ui-core';
+import {
+  classifyNow,
+  getInquiryDetail,
+  listInquiries,
+  postAnswer,
+  reassignInquiry,
+  type Inquiry,
+  type InquirySearch,
+  type ResolutionState,
+} from '../../api/inquiries';
+
+const CATEGORY_LABELS: Record<string, string> = {
+  ACADEMIC: '학사·강의',
+  ORDER: '수강·결제·배송',
+  SYSTEM: '시스템·기술',
+  OTHER: '기타',
+};
+const CATEGORY_COLORS: Record<string, string> = {
+  ACADEMIC: 'geekblue',
+  ORDER: 'orange',
+  SYSTEM: 'purple',
+  OTHER: 'default',
+};
+const STATE_COLORS: Record<string, string> = {
+  OPEN: 'red',
+  ANSWERED: 'blue',
+  RESOLVED: 'green',
+  CLOSED: 'default',
+};
+
+export function InquiriesPage() {
+  const qc = useQueryClient();
+  const [searchForm] = Form.useForm<InquirySearch>();
+  const [answerForm] = Form.useForm<{ answerBody: string; resolutionState: ResolutionState }>();
+  const [reassignForm] = Form.useForm<{ toCategory: string; toUser: string; reason?: string; isAiError?: boolean }>();
+
+  const [filter, setFilter] = useState<InquirySearch>({});
+  const [page, setPage] = useState(1);
+  const [size, setSize] = useState(20);
+  const [detailTarget, setDetailTarget] = useState<number | null>(null);
+  const [reassignOpen, setReassignOpen] = useState(false);
+
+  const params: InquirySearch = useMemo(
+    () => ({ ...filter, page, size }),
+    [filter, page, size],
+  );
+
+  const list = useQuery({
+    queryKey: ['inquiries', params],
+    queryFn: () => listInquiries(params),
+    placeholderData: (p) => p,
+  });
+
+  const detail = useQuery({
+    queryKey: ['inquiry-detail', detailTarget],
+    queryFn: () => (detailTarget ? getInquiryDetail(detailTarget) : Promise.resolve(null)),
+    enabled: detailTarget !== null,
+  });
+
+  const invalidate = () => {
+    qc.invalidateQueries({ queryKey: ['inquiries'] });
+    if (detailTarget) qc.invalidateQueries({ queryKey: ['inquiry-detail', detailTarget] });
+  };
+
+  const classifyMut = useMutation({
+    mutationFn: classifyNow,
+    onSuccess: () => { message.success('AI 분류 완료'); invalidate(); },
+    onError: (e: Error) => message.error('AI 분류 실패: ' + e.message),
+  });
+
+  const answerMut = useMutation({
+    mutationFn: (v: { csSeq: number; answerBody: string; state?: ResolutionState }) =>
+      postAnswer(v.csSeq, v.answerBody, v.state),
+    onSuccess: () => { message.success('답변 저장'); answerForm.resetFields(['answerBody']); invalidate(); },
+    onError: (e: Error) => message.error(e.message),
+  });
+
+  const reassignMut = useMutation({
+    mutationFn: (v: { csSeq: number; toCategory: string; toUser: string; reason?: string; isAiError?: boolean }) =>
+      reassignInquiry(v.csSeq, v),
+    onSuccess: () => { message.success('재배정 완료'); setReassignOpen(false); reassignForm.resetFields(); invalidate(); },
+    onError: (e: Error) => message.error(e.message),
+  });
+
+  const columns: ColumnsType<Inquiry> = [
+    { title: '#', dataIndex: 'csSeq', key: 'csSeq', width: 70 },
+    {
+      title: '제목',
+      dataIndex: 'inquiryTitle',
+      key: 'inquiryTitle',
+      ellipsis: true,
+      render: (v, row) => <a onClick={() => setDetailTarget(row.csSeq)}>{v}</a>,
+    },
+    {
+      title: '작성자',
+      dataIndex: 'inquiryName',
+      key: 'inquiryName',
+      width: 110,
+    },
+    {
+      title: '카테고리',
+      key: 'category',
+      width: 160,
+      render: (_, row) => {
+        const cat = row.actualCategory || row.predictedCategory;
+        if (!cat) return <Tag color="default">미분류</Tag>;
+        const conf = row.predictedConfidence ? Number(row.predictedConfidence) : null;
+        return (
+          <Space size={4} direction="vertical" style={{ lineHeight: 1.3 }}>
+            <Tag color={CATEGORY_COLORS[cat] ?? 'default'}>{CATEGORY_LABELS[cat] ?? cat}</Tag>
+            {row.actualCategory ? (
+              <span style={{ fontSize: 11, color: '#64748b' }}>(확정)</span>
+            ) : conf !== null ? (
+              <span style={{ fontSize: 11, color: '#64748b' }}>AI {(conf * 100).toFixed(0)}%</span>
+            ) : null}
+          </Space>
+        );
+      },
+    },
+    {
+      title: '상태',
+      dataIndex: 'resolutionState',
+      key: 'resolutionState',
+      width: 100,
+      render: (v: string) => <Badge color={STATE_COLORS[v] ?? 'default'} text={v} />,
+    },
+    {
+      title: '담당자',
+      dataIndex: 'assignedTo',
+      key: 'assignedTo',
+      width: 110,
+      render: (v) => v || '-',
+    },
+    {
+      title: '접수일',
+      dataIndex: 'inquiryDate',
+      key: 'inquiryDate',
+      width: 120,
+      render: (v: string) => (v ? v.slice(0, 10) : '-'),
+    },
+  ];
+
+  const target = detail.data ?? null;
+  const currentCategory = target?.actualCategory || target?.predictedCategory;
+
+  return (
+    <PageContainer
+      title="1:1 문의 응대"
+      crumbs={[{ label: '고객센터' }, { label: '1:1 문의 응대' }]}
+      extra={
+        <Space>
+          <Button icon={<ReloadOutlined />} onClick={() => list.refetch()}>
+            새로고침
+          </Button>
+        </Space>
+      }
+    >
+      <Alert
+        type="info"
+        showIcon
+        style={{ marginBottom: 16 }}
+        message="Phase C — AI 분류는 agent (qwen2.5:7b) 가 처리. 운영자가 재배정하면 학습 데이터에 누적."
+        description="데이터가 없을 경우 Phase A ETL 을 먼저 실행하세요: scripts/data-migrate/board/"
+      />
+
+      <Form<InquirySearch>
+        form={searchForm}
+        layout="inline"
+        onFinish={(v) => { setFilter(v); setPage(1); }}
+        style={{ marginBottom: 16, rowGap: 8 }}
+      >
+        <Form.Item name="keyword" label="키워드">
+          <Input allowClear placeholder="제목·본문" style={{ width: 220 }} />
+        </Form.Item>
+        <Form.Item name="category" label="카테고리" initialValue="">
+          <Select
+            style={{ width: 170 }}
+            options={[
+              { value: '', label: '전체' },
+              { value: 'ACADEMIC', label: '학사·강의' },
+              { value: 'ORDER', label: '수강·결제·배송' },
+              { value: 'SYSTEM', label: '시스템·기술' },
+              { value: 'OTHER', label: '기타' },
+            ]}
+          />
+        </Form.Item>
+        <Form.Item name="resolutionState" label="상태" initialValue="">
+          <Select
+            style={{ width: 140 }}
+            options={[
+              { value: '', label: '전체' },
+              { value: 'OPEN', label: '대기 (OPEN)' },
+              { value: 'ANSWERED', label: '답변 (ANSWERED)' },
+              { value: 'RESOLVED', label: '해결 (RESOLVED)' },
+              { value: 'CLOSED', label: '종료 (CLOSED)' },
+            ]}
+          />
+        </Form.Item>
+        <Form.Item name="assignedTo" label="담당자">
+          <Input allowClear placeholder="user_id" style={{ width: 150 }} />
+        </Form.Item>
+        <Form.Item>
+          <Space>
+            <Button type="primary" htmlType="submit" icon={<SearchOutlined />}>검색</Button>
+            <Button onClick={() => { searchForm.resetFields(); setFilter({}); setPage(1); }}>초기화</Button>
+          </Space>
+        </Form.Item>
+      </Form>
+
+      <Table<Inquiry>
+        rowKey="csSeq"
+        columns={columns}
+        dataSource={list.data?.items ?? []}
+        loading={list.isFetching}
+        scroll={{ x: 1100 }}
+        size="middle"
+        pagination={{
+          current: page,
+          pageSize: size,
+          total: Number(list.data?.totalItems ?? 0),
+          showSizeChanger: true,
+          showTotal: (t) => `총 ${t.toLocaleString()}건`,
+          onChange: (p, s) => { setPage(p); setSize(s); },
+        }}
+      />
+
+      <Drawer
+        title={target ? `문의 #${target.csSeq} — ${target.inquiryTitle}` : '문의 상세'}
+        width={720}
+        open={detailTarget !== null}
+        onClose={() => setDetailTarget(null)}
+        destroyOnClose
+        loading={detail.isLoading}
+        extra={
+          target && (
+            <Space>
+              <Button
+                icon={<ThunderboltOutlined />}
+                loading={classifyMut.isPending}
+                onClick={() => classifyMut.mutate(target.csSeq)}
+              >
+                AI 재분류
+              </Button>
+              <Button onClick={() => setReassignOpen(true)}>재배정</Button>
+            </Space>
+          )
+        }
+      >
+        {target && (
+          <>
+            <Descriptions column={2} bordered size="small" style={{ marginBottom: 16 }}>
+              <Descriptions.Item label="작성자">{target.inquiryName} ({target.inquiryUserId})</Descriptions.Item>
+              <Descriptions.Item label="접수일">{target.inquiryDate?.slice(0, 19).replace('T', ' ')}</Descriptions.Item>
+              <Descriptions.Item label="AI 분류">
+                {target.predictedCategory ? (
+                  <Space>
+                    <Tag color={CATEGORY_COLORS[target.predictedCategory] ?? 'default'}>
+                      {CATEGORY_LABELS[target.predictedCategory] ?? target.predictedCategory}
+                    </Tag>
+                    {target.predictedConfidence && (
+                      <Progress
+                        percent={Math.round(Number(target.predictedConfidence) * 100)}
+                        size="small"
+                        steps={10}
+                        style={{ minWidth: 180 }}
+                      />
+                    )}
+                  </Space>
+                ) : '미분류'}
+              </Descriptions.Item>
+              <Descriptions.Item label="확정 분류">
+                {target.actualCategory ? (
+                  <Tag color={CATEGORY_COLORS[target.actualCategory] ?? 'default'}>
+                    {CATEGORY_LABELS[target.actualCategory] ?? target.actualCategory}
+                  </Tag>
+                ) : '-'}
+              </Descriptions.Item>
+              <Descriptions.Item label="담당자">{target.assignedTo || '-'}</Descriptions.Item>
+              <Descriptions.Item label="재배정 횟수">{target.rerouteCount}</Descriptions.Item>
+              <Descriptions.Item label="상태" span={2}>
+                <Badge color={STATE_COLORS[target.resolutionState] ?? 'default'} text={target.resolutionState} />
+              </Descriptions.Item>
+              <Descriptions.Item label="모델" span={2}>
+                {target.classifiedByModel ? `${target.classifiedByModel} @ ${target.classifiedAt?.slice(0, 19).replace('T', ' ')}` : '-'}
+              </Descriptions.Item>
+            </Descriptions>
+
+            <h4>본문</h4>
+            <div
+              style={{
+                padding: 12,
+                background: '#f8fafc',
+                borderRadius: 6,
+                whiteSpace: 'pre-wrap',
+                wordBreak: 'break-word',
+                maxHeight: 300,
+                overflowY: 'auto',
+              }}
+              dangerouslySetInnerHTML={{ __html: target.body || '(본문 없음)' }}
+            />
+
+            {target.answerBody && (
+              <>
+                <h4 style={{ marginTop: 20 }}>기존 답변</h4>
+                <div
+                  style={{
+                    padding: 12,
+                    background: '#eff6ff',
+                    borderRadius: 6,
+                    whiteSpace: 'pre-wrap',
+                    wordBreak: 'break-word',
+                  }}
+                  dangerouslySetInnerHTML={{ __html: target.answerBody }}
+                />
+              </>
+            )}
+
+            <h4 style={{ marginTop: 20 }}>답변 {target.answerBody ? '수정' : '등록'}</h4>
+            <Form
+              form={answerForm}
+              layout="vertical"
+              onFinish={(v) =>
+                answerMut.mutate({
+                  csSeq: target.csSeq,
+                  answerBody: v.answerBody,
+                  state: v.resolutionState,
+                })
+              }
+            >
+              <Form.Item name="answerBody" rules={[{ required: true, message: '답변 본문을 입력하세요.' }]}>
+                <Input.TextArea rows={6} placeholder="답변 내용 (Markdown/HTML)" />
+              </Form.Item>
+              <Form.Item name="resolutionState" label="처리 상태" initialValue="ANSWERED">
+                <Select
+                  style={{ width: 200 }}
+                  options={[
+                    { value: 'ANSWERED', label: '답변 완료' },
+                    { value: 'RESOLVED', label: '해결됨' },
+                    { value: 'CLOSED', label: '종료' },
+                  ]}
+                />
+              </Form.Item>
+              <Button type="primary" htmlType="submit" loading={answerMut.isPending}>
+                답변 저장
+              </Button>
+            </Form>
+          </>
+        )}
+      </Drawer>
+
+      <Drawer
+        title="카테고리·담당자 재배정"
+        width={420}
+        open={reassignOpen}
+        onClose={() => setReassignOpen(false)}
+        destroyOnClose
+      >
+        {target && (
+          <Form
+            form={reassignForm}
+            layout="vertical"
+            initialValues={{ toCategory: currentCategory ?? 'OTHER', isAiError: true }}
+            onFinish={(v) => reassignMut.mutate({ csSeq: target.csSeq, ...v })}
+          >
+            <Form.Item name="toCategory" label="새 카테고리" rules={[{ required: true }]}>
+              <Select
+                options={[
+                  { value: 'ACADEMIC', label: '학사·강의' },
+                  { value: 'ORDER', label: '수강·결제·배송' },
+                  { value: 'SYSTEM', label: '시스템·기술' },
+                  { value: 'OTHER', label: '기타' },
+                ]}
+              />
+            </Form.Item>
+            <Form.Item name="toUser" label="담당자 user_id" rules={[{ required: true }]}>
+              <Input placeholder="admin" />
+            </Form.Item>
+            <Form.Item name="reason" label="사유">
+              <Input.TextArea rows={3} />
+            </Form.Item>
+            <Form.Item name="isAiError" label="AI 오분류로 기록" valuePropName="checked">
+              <Select
+                options={[
+                  { value: true, label: 'Y (학습 셋에 포함)' },
+                  { value: false, label: 'N (일반 재배정)' },
+                ]}
+              />
+            </Form.Item>
+            <Button type="primary" htmlType="submit" loading={reassignMut.isPending}>
+              재배정 실행
+            </Button>
+          </Form>
+        )}
+      </Drawer>
+    </PageContainer>
+  );
+}

--- a/backend/src/main/java/com/academy/inquiry/InquiryApi.java
+++ b/backend/src/main/java/com/academy/inquiry/InquiryApi.java
@@ -1,0 +1,112 @@
+package com.academy.inquiry;
+
+import com.academy.inquiry.dto.AnswerRequest;
+import com.academy.inquiry.dto.InquiryDto;
+import com.academy.inquiry.dto.InquirySearchRequest;
+import com.academy.inquiry.dto.ReassignRequest;
+import com.academy.inquiry.service.InquiryAgentClient;
+import com.academy.inquiry.service.InquiryService;
+import com.academy.shared.common.ApiResponse;
+import com.academy.shared.common.PagedResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 관리자 콘솔용 CS 문의 응대 API. (CS_INQUIRY_AI_PLAN Phase C)
+ *
+ * <p>ROLE_ADMIN 보호 — SecurityConfig 가 {@code /api/**} 전역 hasRole(ADMIN) 적용.
+ * academy-agent (로컬 Ollama) HTTP 로 분류·유사추천·피드백.
+ */
+@RestController
+@RequestMapping("/api/inquiries")
+@Tag(name = "Inquiries", description = "CS 1:1 문의 운영자 콘솔")
+public class InquiryApi {
+
+    private final InquiryService service;
+
+    public InquiryApi(InquiryService service) {
+        this.service = service;
+    }
+
+    @Operation(summary = "문의 목록 (검색·페이징)")
+    @GetMapping
+    public ApiResponse<PagedResponse<InquiryDto>> list(InquirySearchRequest req) {
+        return ApiResponse.ok(service.list(req));
+    }
+
+    @Operation(summary = "문의 상세")
+    @GetMapping("/{csSeq}")
+    public ResponseEntity<ApiResponse<InquiryDto>> detail(@PathVariable long csSeq) {
+        InquiryDto d = service.detail(csSeq);
+        if (d == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiResponse.fail("INQUIRY_404", "문의를 찾을 수 없습니다."));
+        }
+        return ResponseEntity.ok(ApiResponse.ok(d));
+    }
+
+    @Operation(summary = "AI 분류 재실행 (agent 호출)")
+    @PostMapping("/{csSeq}/classify")
+    public ResponseEntity<ApiResponse<InquiryDto>> classifyNow(@PathVariable long csSeq) {
+        try {
+            InquiryDto d = service.classifyNow(csSeq);
+            if (d == null) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(ApiResponse.fail("INQUIRY_404", "문의를 찾을 수 없습니다."));
+            }
+            return ResponseEntity.ok(ApiResponse.ok(d));
+        } catch (InquiryAgentClient.AgentException e) {
+            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                .body(ApiResponse.fail("AGENT_UNAVAILABLE", e.getMessage()));
+        }
+    }
+
+    @Operation(summary = "답변 저장")
+    @PostMapping("/{csSeq}/answer")
+    public ResponseEntity<ApiResponse<InquiryDto>> answer(
+        @PathVariable long csSeq,
+        @Valid @RequestBody AnswerRequest req,
+        Authentication auth
+    ) {
+        String userId = auth != null ? String.valueOf(auth.getPrincipal()) : "system";
+        InquiryDto d = service.answer(csSeq, req, userId);
+        return ResponseEntity.ok(ApiResponse.ok(d));
+    }
+
+    @Operation(summary = "담당자·카테고리 재배정")
+    @PostMapping("/{csSeq}/reassign")
+    public ResponseEntity<ApiResponse<InquiryDto>> reassign(
+        @PathVariable long csSeq,
+        @Valid @RequestBody ReassignRequest req,
+        Authentication auth
+    ) {
+        String userId = auth != null ? String.valueOf(auth.getPrincipal()) : "system";
+        InquiryDto d = service.reassign(csSeq, req, userId);
+        if (d == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiResponse.fail("INQUIRY_404", "문의를 찾을 수 없습니다."));
+        }
+        return ResponseEntity.ok(ApiResponse.ok(d));
+    }
+
+    @Operation(summary = "유사 문의 추천 (agent 호출)")
+    @GetMapping("/{csSeq}/related")
+    public ResponseEntity<ApiResponse<InquiryAgentClient.SuggestResponse>> related(@PathVariable long csSeq) {
+        try {
+            InquiryAgentClient.SuggestResponse r = service.related(csSeq);
+            if (r == null) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(ApiResponse.fail("INQUIRY_404", "문의를 찾을 수 없습니다."));
+            }
+            return ResponseEntity.ok(ApiResponse.ok(r));
+        } catch (InquiryAgentClient.AgentException e) {
+            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                .body(ApiResponse.fail("AGENT_UNAVAILABLE", e.getMessage()));
+        }
+    }
+}

--- a/backend/src/main/java/com/academy/inquiry/dto/AnswerRequest.java
+++ b/backend/src/main/java/com/academy/inquiry/dto/AnswerRequest.java
@@ -1,0 +1,8 @@
+package com.academy.inquiry.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AnswerRequest(
+    @NotBlank String answerBody,
+    String resolutionState  // 미지정시 ANSWERED
+) {}

--- a/backend/src/main/java/com/academy/inquiry/dto/InquiryDto.java
+++ b/backend/src/main/java/com/academy/inquiry/dto/InquiryDto.java
@@ -1,0 +1,37 @@
+package com.academy.inquiry.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * 문의 목록·상세 공통 응답 record.
+ *
+ * <p>{@code bodyPreview} 는 목록에서만 사용 (본문 HTML 일부 텍스트만).
+ * {@code body} 는 상세 조회에서만 채워짐.
+ */
+public record InquiryDto(
+    long csSeq,
+    String inquiryUserId,
+    String inquiryName,
+    String inquiryTitle,
+    String bodyPreview,
+    String body,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    LocalDateTime inquiryDate,
+    String predictedCategory,
+    BigDecimal predictedConfidence,
+    String classifiedByModel,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    LocalDateTime classifiedAt,
+    String actualCategory,
+    String assignedTo,
+    int rerouteCount,
+    String answerBody,
+    String answeredBy,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    LocalDateTime answeredAt,
+    String resolutionState,
+    Integer userSatisfaction
+) {}

--- a/backend/src/main/java/com/academy/inquiry/dto/InquirySearchRequest.java
+++ b/backend/src/main/java/com/academy/inquiry/dto/InquirySearchRequest.java
@@ -1,0 +1,26 @@
+package com.academy.inquiry.dto;
+
+/**
+ * 문의 검색·페이징 요청. 모든 필드 optional.
+ * category 는 actual_category 또는 predicted_category 중 우선순위로 매칭.
+ */
+public record InquirySearchRequest(
+    String category,         // ACADEMIC | ORDER | SYSTEM | OTHER
+    String resolutionState,  // OPEN | ANSWERED | RESOLVED | CLOSED
+    String keyword,          // title/body LIKE
+    String assignedTo,
+    Integer page,            // 1-based
+    Integer size
+) {
+    public int pageOrDefault() {
+        return (page == null || page < 1) ? 1 : page;
+    }
+
+    public int sizeOrDefault() {
+        return (size == null || size < 1 || size > 200) ? 20 : size;
+    }
+
+    public int offset() {
+        return (pageOrDefault() - 1) * sizeOrDefault();
+    }
+}

--- a/backend/src/main/java/com/academy/inquiry/dto/ReassignRequest.java
+++ b/backend/src/main/java/com/academy/inquiry/dto/ReassignRequest.java
@@ -1,0 +1,13 @@
+package com.academy.inquiry.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * 담당자·카테고리 재배정. is_ai_error=true 시 학습 셋 포함 (routing_log 기록).
+ */
+public record ReassignRequest(
+    @NotBlank String toCategory,
+    @NotBlank String toUser,
+    String reason,
+    boolean isAiError
+) {}

--- a/backend/src/main/java/com/academy/inquiry/service/InquiryAgentClient.java
+++ b/backend/src/main/java/com/academy/inquiry/service/InquiryAgentClient.java
@@ -1,0 +1,117 @@
+package com.academy.inquiry.service;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * academy-agent (:9011) HTTP 클라이언트.
+ *
+ * <p>docker-compose 네트워크에서 {@code http://academy-agent:9011} 로 접근.
+ * 외부에선 {@code http://localhost:9011} (개발). 환경변수 {@code ACADEMY_AGENT_URL}
+ * 로 오버라이드.
+ *
+ * <p>실패 시 예외 전파 — 호출부에서 fallback 결정.
+ */
+@Component
+public class InquiryAgentClient {
+
+    private static final Logger log = LoggerFactory.getLogger(InquiryAgentClient.class);
+
+    private final HttpClient http = HttpClient.newBuilder()
+        .connectTimeout(Duration.ofSeconds(3))
+        .build();
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private final String baseUrl;
+
+    public InquiryAgentClient(@Value("${academy.agent.url:http://academy-agent:9011}") String baseUrl) {
+        this.baseUrl = baseUrl.replaceAll("/+$", "");
+    }
+
+    public ClassifyResponse classify(String title, String body) throws AgentException {
+        return post("/classify",
+            Map.of("title", title == null ? "" : title,
+                   "body",  body  == null ? "" : body),
+            ClassifyResponse.class);
+    }
+
+    public SuggestResponse suggestRelated(String draftBody, Integer topK) throws AgentException {
+        return post("/suggest-related",
+            Map.of("draft_body", draftBody == null ? "" : draftBody,
+                   "top_k", topK == null ? 3 : topK),
+            SuggestResponse.class);
+    }
+
+    public void recordFeedback(long csSeq, String fromCategory, String toCategory,
+                               String toUser, String changedBy, String reason, boolean aiError)
+        throws AgentException {
+        post("/route-feedback",
+            Map.of("cs_seq", csSeq,
+                   "from_category", fromCategory == null ? "" : fromCategory,
+                   "to_category", toCategory,
+                   "to_user", toUser,
+                   "changed_by", changedBy,
+                   "reason", reason == null ? "" : reason,
+                   "is_ai_error", aiError),
+            Map.class);
+    }
+
+    private <T> T post(String path, Object payload, Class<T> cls) throws AgentException {
+        try {
+            String json = mapper.writeValueAsString(payload);
+            HttpRequest req = HttpRequest.newBuilder(URI.create(baseUrl + path))
+                .timeout(Duration.ofSeconds(30))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(json))
+                .build();
+            HttpResponse<String> res = http.send(req, HttpResponse.BodyHandlers.ofString());
+            if (res.statusCode() >= 400) {
+                throw new AgentException("agent " + path + " http " + res.statusCode() + ": " + res.body());
+            }
+            return mapper.readValue(res.body(), cls);
+        } catch (Exception e) {
+            log.warn("agent {} 호출 실패: {}", path, e.getMessage());
+            throw new AgentException("agent 호출 실패: " + e.getMessage(), e);
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record ClassifyResponse(
+        String category,
+        BigDecimal confidence,
+        String reasoning,
+        String model,
+        int latency_ms,
+        boolean used_fallback
+    ) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record RelatedItem(
+        long cs_seq,
+        String title,
+        String answer_excerpt,
+        BigDecimal similarity,
+        String category
+    ) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record SuggestResponse(List<RelatedItem> items, int query_embedding_dim, String model) {}
+
+    public static class AgentException extends Exception {
+        public AgentException(String message) { super(message); }
+        public AgentException(String message, Throwable cause) { super(message, cause); }
+    }
+}

--- a/backend/src/main/java/com/academy/inquiry/service/InquiryService.java
+++ b/backend/src/main/java/com/academy/inquiry/service/InquiryService.java
@@ -1,0 +1,109 @@
+package com.academy.inquiry.service;
+
+import com.academy.inquiry.dto.AnswerRequest;
+import com.academy.inquiry.dto.InquiryDto;
+import com.academy.inquiry.dto.InquirySearchRequest;
+import com.academy.inquiry.dto.ReassignRequest;
+import com.academy.mapper.InquiryMapper;
+import com.academy.shared.common.PagedResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+public class InquiryService implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+    private static final Logger log = LoggerFactory.getLogger(InquiryService.class);
+
+    private final InquiryMapper mapper;
+    private final InquiryAgentClient agent;
+
+    public InquiryService(InquiryMapper mapper, InquiryAgentClient agent) {
+        this.mapper = mapper;
+        this.agent = agent;
+    }
+
+    @Transactional(readOnly = true)
+    public PagedResponse<InquiryDto> list(InquirySearchRequest req) {
+        List<InquiryDto> items = mapper.selectList(req);
+        long total = mapper.selectCount(req);
+        return PagedResponse.of(items, req.pageOrDefault(), req.sizeOrDefault(), total);
+    }
+
+    @Transactional(readOnly = true)
+    public InquiryDto detail(long csSeq) {
+        return mapper.selectDetail(csSeq);
+    }
+
+    /** agent 호출 → 분류 결과 저장. 실패시 예외 전파. */
+    @Transactional
+    public InquiryDto classifyNow(long csSeq) throws InquiryAgentClient.AgentException {
+        InquiryDto current = mapper.selectDetail(csSeq);
+        if (current == null) return null;
+
+        InquiryAgentClient.ClassifyResponse r = agent.classify(current.inquiryTitle(), current.body());
+
+        LocalDateTime now = LocalDateTime.now();
+        mapper.updateClassification(csSeq, r.category(), r.confidence(), r.model(), now);
+        mapper.insertAnalysisLog(csSeq, r.model(), "v1", r.category(), r.confidence(),
+            r.latency_ms(), truncate(r.reasoning(), 2000));
+
+        return mapper.selectDetail(csSeq);
+    }
+
+    @Transactional
+    public InquiryDto answer(long csSeq, AnswerRequest req, String answeredBy) {
+        String state = (req.resolutionState() == null || req.resolutionState().isBlank())
+            ? "ANSWERED" : req.resolutionState();
+        mapper.updateAnswer(csSeq, req.answerBody(), answeredBy, state, LocalDateTime.now());
+        return mapper.selectDetail(csSeq);
+    }
+
+    @Transactional
+    public InquiryDto reassign(long csSeq, ReassignRequest req, String changedBy) {
+        InquiryDto current = mapper.selectDetail(csSeq);
+        if (current == null) return null;
+
+        String fromCategory = current.actualCategory() != null
+            ? current.actualCategory() : current.predictedCategory();
+        String fromUser = current.assignedTo();
+
+        mapper.updateReassign(csSeq, req.toCategory(), req.toUser());
+        mapper.insertRoutingLog(
+            csSeq, fromCategory, req.toCategory(), fromUser, req.toUser(),
+            req.reason(), changedBy, req.isAiError() ? "Y" : "N"
+        );
+
+        // agent 에도 피드백 (best-effort, 실패해도 진행)
+        try {
+            agent.recordFeedback(csSeq, fromCategory, req.toCategory(),
+                req.toUser(), changedBy, req.reason(), req.isAiError());
+        } catch (Exception e) {
+            log.warn("agent 피드백 실패 (무시): {}", e.getMessage());
+        }
+
+        return mapper.selectDetail(csSeq);
+    }
+
+    public InquiryAgentClient.SuggestResponse related(long csSeq) throws InquiryAgentClient.AgentException {
+        InquiryDto d = mapper.selectDetail(csSeq);
+        if (d == null) return null;
+        return agent.suggestRelated(d.body(), 3);
+    }
+
+    private static String truncate(String s, int max) {
+        if (s == null) return null;
+        return s.length() > max ? s.substring(0, max) : s;
+    }
+
+    // 시그니처 미사용 — Jackson 직렬화용 더미 필드 아님
+    @SuppressWarnings("unused")
+    private static BigDecimal _unused;
+}

--- a/backend/src/main/java/com/academy/mapper/InquiryMapper.java
+++ b/backend/src/main/java/com/academy/mapper/InquiryMapper.java
@@ -1,0 +1,63 @@
+package com.academy.mapper;
+
+import com.academy.inquiry.dto.InquiryDto;
+import com.academy.inquiry.dto.InquirySearchRequest;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Mapper
+public interface InquiryMapper {
+
+    List<InquiryDto> selectList(@Param("req") InquirySearchRequest req);
+
+    long selectCount(@Param("req") InquirySearchRequest req);
+
+    InquiryDto selectDetail(@Param("csSeq") long csSeq);
+
+    int updateClassification(
+        @Param("csSeq") long csSeq,
+        @Param("category") String category,
+        @Param("confidence") BigDecimal confidence,
+        @Param("model") String model,
+        @Param("classifiedAt") LocalDateTime classifiedAt
+    );
+
+    int updateAnswer(
+        @Param("csSeq") long csSeq,
+        @Param("body") String answerBody,
+        @Param("by") String answeredBy,
+        @Param("state") String resolutionState,
+        @Param("answeredAt") LocalDateTime answeredAt
+    );
+
+    int updateReassign(
+        @Param("csSeq") long csSeq,
+        @Param("toCategory") String toCategory,
+        @Param("toUser") String toUser
+    );
+
+    int insertRoutingLog(
+        @Param("csSeq") long csSeq,
+        @Param("fromCategory") String fromCategory,
+        @Param("toCategory") String toCategory,
+        @Param("fromUser") String fromUser,
+        @Param("toUser") String toUser,
+        @Param("reason") String reason,
+        @Param("changedBy") String changedBy,
+        @Param("isAiError") String isAiError
+    );
+
+    int insertAnalysisLog(
+        @Param("csSeq") long csSeq,
+        @Param("modelName") String modelName,
+        @Param("promptTemplate") String promptTemplate,
+        @Param("parsedCategory") String parsedCategory,
+        @Param("confidence") BigDecimal confidence,
+        @Param("latencyMs") Integer latencyMs,
+        @Param("rawOutput") String rawOutput
+    );
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -84,6 +84,10 @@ app:
     refresh-ttl: ${JWT_REFRESH_TTL:P14D}
   google:
     client-id: ${GOOGLE_CLIENT_ID:}
+  agent:
+    # academy-agent (services/agent) HTTP endpoint. docker-compose 내부에선
+    # 서비스명, 로컬 개발에선 localhost:9011.
+    url: ${ACADEMY_AGENT_URL:http://academy-agent:9011}
 
 logging:
   level:

--- a/backend/src/main/resources/mapper/inquiry.xml
+++ b/backend/src/main/resources/mapper/inquiry.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<!--
+  CS 문의 운영자 콘솔용 쿼리. acm_board_cs (Phase A) 기반.
+-->
+<mapper namespace="com.academy.mapper.InquiryMapper">
+
+    <sql id="listWhere">
+        <where>
+            is_deleted = 'N'
+            <if test="req.category != null and req.category != ''">
+                AND (actual_category = #{req.category}
+                     OR (actual_category IS NULL AND predicted_category = #{req.category}))
+            </if>
+            <if test="req.resolutionState != null and req.resolutionState != ''">
+                AND resolution_state = #{req.resolutionState}
+            </if>
+            <if test="req.assignedTo != null and req.assignedTo != ''">
+                AND assigned_to = #{req.assignedTo}
+            </if>
+            <if test="req.keyword != null and req.keyword != ''">
+                AND (inquiry_title LIKE CONCAT('%', #{req.keyword}, '%')
+                     OR inquiry_body LIKE CONCAT('%', #{req.keyword}, '%'))
+            </if>
+        </where>
+    </sql>
+
+    <select id="selectList" resultType="com.academy.inquiry.dto.InquiryDto">
+        SELECT
+            cs_seq                AS csSeq,
+            inquiry_user_id       AS inquiryUserId,
+            inquiry_name          AS inquiryName,
+            inquiry_title         AS inquiryTitle,
+            LEFT(inquiry_body, 200)  AS bodyPreview,
+            NULL                  AS body,
+            inquiry_date          AS inquiryDate,
+            predicted_category    AS predictedCategory,
+            predicted_confidence  AS predictedConfidence,
+            classified_by_model   AS classifiedByModel,
+            classified_at         AS classifiedAt,
+            actual_category       AS actualCategory,
+            assigned_to           AS assignedTo,
+            reroute_count         AS rerouteCount,
+            NULL                  AS answerBody,
+            answered_by           AS answeredBy,
+            answered_at           AS answeredAt,
+            resolution_state      AS resolutionState,
+            user_satisfaction     AS userSatisfaction
+        FROM acm_board_cs
+        <include refid="listWhere"/>
+        ORDER BY inquiry_date DESC, cs_seq DESC
+        LIMIT #{req.sizeOrDefault} OFFSET #{req.offset}
+    </select>
+
+    <select id="selectCount" resultType="long">
+        SELECT COUNT(*) FROM acm_board_cs
+        <include refid="listWhere"/>
+    </select>
+
+    <select id="selectDetail" resultType="com.academy.inquiry.dto.InquiryDto">
+        SELECT
+            cs_seq                AS csSeq,
+            inquiry_user_id       AS inquiryUserId,
+            inquiry_name          AS inquiryName,
+            inquiry_title         AS inquiryTitle,
+            NULL                  AS bodyPreview,
+            inquiry_body          AS body,
+            inquiry_date          AS inquiryDate,
+            predicted_category    AS predictedCategory,
+            predicted_confidence  AS predictedConfidence,
+            classified_by_model   AS classifiedByModel,
+            classified_at         AS classifiedAt,
+            actual_category       AS actualCategory,
+            assigned_to           AS assignedTo,
+            reroute_count         AS rerouteCount,
+            answer_body           AS answerBody,
+            answered_by           AS answeredBy,
+            answered_at           AS answeredAt,
+            resolution_state      AS resolutionState,
+            user_satisfaction     AS userSatisfaction
+        FROM acm_board_cs
+        WHERE cs_seq = #{csSeq}
+          AND is_deleted = 'N'
+    </select>
+
+    <update id="updateClassification">
+        UPDATE acm_board_cs
+           SET predicted_category   = #{category},
+               predicted_confidence = #{confidence},
+               classified_by_model  = #{model},
+               classified_at        = #{classifiedAt}
+         WHERE cs_seq = #{csSeq}
+    </update>
+
+    <update id="updateAnswer">
+        UPDATE acm_board_cs
+           SET answer_body      = #{body},
+               answered_by      = #{by},
+               answered_at      = #{answeredAt},
+               resolution_state = #{state},
+               upd_dt           = CURRENT_TIMESTAMP
+         WHERE cs_seq = #{csSeq}
+    </update>
+
+    <update id="updateReassign">
+        UPDATE acm_board_cs
+           SET actual_category = #{toCategory},
+               assigned_to     = #{toUser},
+               reroute_count   = reroute_count + 1,
+               upd_dt          = CURRENT_TIMESTAMP
+         WHERE cs_seq = #{csSeq}
+    </update>
+
+    <insert id="insertRoutingLog">
+        INSERT INTO acm_inquiry_routing_log (
+            cs_seq, from_category, to_category, from_user, to_user,
+            reason, changed_by, is_ai_error
+        ) VALUES (
+            #{csSeq}, #{fromCategory}, #{toCategory}, #{fromUser}, #{toUser},
+            #{reason}, #{changedBy}, #{isAiError}
+        )
+    </insert>
+
+    <insert id="insertAnalysisLog">
+        INSERT INTO acm_inquiry_analysis (
+            cs_seq, model_name, prompt_template, parsed_category,
+            confidence, latency_ms, raw_output
+        ) VALUES (
+            #{csSeq}, #{modelName}, #{promptTemplate}, #{parsedCategory},
+            #{confidence}, #{latencyMs}, #{rawOutput}
+        )
+    </insert>
+
+</mapper>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       ADMIN_USERNAMES: ${ADMIN_USERNAMES:-admin,rainend}
       ADMIN_PASSWORD: ${ADMIN_PASSWORD:-dnflskfk}
       CORS_ALLOWED_ORIGINS: ${ACADEMY_CORS_ORIGINS:-https://academy.unmong.com,http://localhost:4001,http://localhost:4002}
+      ACADEMY_AGENT_URL: ${ACADEMY_AGENT_URL:-http://academy-agent:9011}
       TZ: ${TZ:-Asia/Seoul}
     ports:
       - "${ACADEMY_BACKEND_PORT:-9001}:9001"

--- a/docs/roles/menu-matrix.md
+++ b/docs/roles/menu-matrix.md
@@ -58,6 +58,7 @@
 | **학사관리** | 과목관리 | ✅ | | 신규 — `/api/subject/*` (Oracle SQL 호환 작업 대기) |
 | | 강의관리 | ✅ | | 신규 — `/api/lecture/*` (동일 대기) |
 | | 강사관리 | ✅ | | 신규 — `acm_member where user_role='PRF'` (members API 재사용) |
+| **고객센터** | 1:1 문의 응대 | ✅ | | 신규 — `/api/inquiries/*` + academy-agent (qwen2.5:7b) AI 분류·재배정 피드백 (Phase C) |
 | | 강의 카테고리 | ✅ | | TBD (DUTYCODE 일반화) |
 | | 강의 승인 | ✅ | | TBD |
 | **주문·결제** | 수강(주문)관리 | ✅ | | 현행 |


### PR DESCRIPTION
## Summary

**Phase C of CS_INQUIRY_AI_PLAN**. backend \`/api/inquiries/*\` + admin-web 고객센터 메뉴 + academy-agent (Phase B) HTTP 연동.

## Backend 엔드포인트 6종

- \`GET  /api/inquiries\` — list·search·paged
- \`GET  /api/inquiries/{seq}\` — detail (본문 포함)
- \`POST /api/inquiries/{seq}/classify\` — agent 호출 → predicted_category 저장 + analysis 로그
- \`POST /api/inquiries/{seq}/answer\` — 답변 저장
- \`POST /api/inquiries/{seq}/reassign\` — 재배정 + routing_log + agent feedback
- \`GET  /api/inquiries/{seq}/related\` — agent /suggest-related 프록시

## Frontend (admin-web)

사이드바 **"고객센터"** 신규 그룹 + **1:1 문의 응대** 페이지:
- 목록: 제목·작성자·카테고리(AI 신뢰도 %)·상태·담당자
- 필터: 키워드·카테고리·상태·담당자
- 상세 Drawer: 본문 HTML·AI 분류 progress bar·기존 답변·답변 폼
- 재배정 Drawer: AI 오분류 체크 → is_ai_error=Y (Phase E 학습 셋)

## 선제 조건

- Phase A ETL 완료 (acm_board_cs 데이터)
- Phase B academy-agent 컨테이너 healthy

데이터 없어도 UI 는 정상 동작 (빈 목록).

## Test plan

- [ ] ci-main (backend mvn test + frontend build) 통과
- [ ] deploy 후 \`GET /admin/api/inquiries?page=1&size=10\` → 200 응답 (items 배열)
- [ ] /admin → "고객센터" 메뉴 노출 + 클릭시 목록 페이지 진입
- [ ] (Phase A ETL 실행된 경우) 샘플 문의 클릭 → AI 재분류 버튼 → agent 호출 → confidence 업데이트