### PR TITLE
feat(phase-d): 유사문의 실시간 추천 + 월간 통계 대시보드

### DIFF
--- a/apps/admin-web/src/api/inquiries.ts
+++ b/apps/admin-web/src/api/inquiries.ts
@@ -95,3 +95,32 @@ export async function getRelated(csSeq: number): Promise<SuggestResponse> {
   const res = await apiClient.get<ApiResponse<SuggestResponse>>(`/inquiries/${csSeq}/related`);
   return unwrap<SuggestResponse>({ data: res.data });
 }
+
+export interface CategoryStat {
+  category: string;
+  totalCount: number;
+  resolvedCount: number;
+  prevMonthCount: number;
+  momDeltaPct: number | null;
+  decreasing: boolean;
+  avgSatisfaction: number | null;
+}
+
+export interface MonthlyStats {
+  yearMonth: string;
+  categories: CategoryStat[];
+  totalInquiries: number;
+  resolvedCount: number;
+  resolutionRate: number | null;
+  aiAccuracyRate: number | null;
+  aiErrorCount: number;
+  totalRoutingChanges: number;
+  unresolvedTop: Inquiry[];
+}
+
+export async function getMonthlyStats(ym: string): Promise<MonthlyStats> {
+  const res = await apiClient.get<ApiResponse<MonthlyStats>>('/inquiries/stats', {
+    params: { ym },
+  });
+  return unwrap<MonthlyStats>({ data: res.data });
+}

--- a/apps/admin-web/src/pages/inquiries/InquiriesPage.tsx
+++ b/apps/admin-web/src/pages/inquiries/InquiriesPage.tsx
@@ -18,6 +18,7 @@ import type { ColumnsType } from 'antd/es/table';
 import { ReloadOutlined, SearchOutlined, ThunderboltOutlined } from '@ant-design/icons';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { PageContainer } from '@academy/ui-core';
+import { InquiryStatsPanel } from './InquiryStatsPanel';
 import {
   classifyNow,
   getInquiryDetail,
@@ -175,11 +176,12 @@ export function InquiriesPage() {
         </Space>
       }
     >
+      <InquiryStatsPanel />
       <Alert
         type="info"
         showIcon
         style={{ marginBottom: 16 }}
-        message="Phase C — AI 분류는 agent (qwen2.5:7b) 가 처리. 운영자가 재배정하면 학습 데이터에 누적."
+        message="AI 분류는 agent (qwen2.5:7b) 가 처리. 운영자가 재배정하면 학습 데이터에 누적."
         description="데이터가 없을 경우 Phase A ETL 을 먼저 실행하세요: scripts/data-migrate/board/"
       />
 

--- a/apps/admin-web/src/pages/inquiries/InquiryStatsPanel.tsx
+++ b/apps/admin-web/src/pages/inquiries/InquiryStatsPanel.tsx
@@ -1,0 +1,164 @@
+import { useMemo, useState } from 'react';
+import { Card, Col, DatePicker, Empty, Progress, Row, Space, Statistic, Table, Tag } from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import { useQuery } from '@tanstack/react-query';
+import { ArrowDownOutlined, ArrowUpOutlined } from '@ant-design/icons';
+import dayjs, { type Dayjs } from 'dayjs';
+import { getMonthlyStats, type CategoryStat } from '../../api/inquiries';
+
+const CAT_LABELS: Record<string, string> = {
+  ACADEMIC: '학사·강의',
+  ORDER: '수강·결제·배송',
+  SYSTEM: '시스템·기술',
+  OTHER: '기타',
+};
+const CAT_COLORS: Record<string, string> = {
+  ACADEMIC: 'geekblue',
+  ORDER: 'orange',
+  SYSTEM: 'purple',
+  OTHER: 'default',
+};
+
+export function InquiryStatsPanel() {
+  const [month, setMonth] = useState<Dayjs>(() => dayjs().startOf('month'));
+  const ym = month.format('YYYY-MM');
+
+  const q = useQuery({
+    queryKey: ['inquiry-stats', ym],
+    queryFn: () => getMonthlyStats(ym),
+    placeholderData: (p) => p,
+  });
+
+  const stats = q.data;
+  const resRate = stats?.resolutionRate;
+  const aiRate = stats?.aiAccuracyRate;
+
+  const catCols: ColumnsType<CategoryStat> = useMemo(
+    () => [
+      {
+        title: '카테고리',
+        dataIndex: 'category',
+        render: (v: string) => (
+          <Tag color={CAT_COLORS[v] ?? 'default'}>{CAT_LABELS[v] ?? v}</Tag>
+        ),
+      },
+      { title: '총건수', dataIndex: 'totalCount', align: 'right', width: 90 },
+      { title: '해결', dataIndex: 'resolvedCount', align: 'right', width: 90 },
+      {
+        title: '전월 대비',
+        dataIndex: 'momDeltaPct',
+        align: 'right',
+        width: 130,
+        render: (v: number | null, row) => {
+          if (v == null) return <span style={{ color: '#94a3b8' }}>-</span>;
+          const icon = row.decreasing ? <ArrowDownOutlined /> : <ArrowUpOutlined />;
+          const color = row.decreasing ? '#16a34a' : '#dc2626';
+          return <span style={{ color }}>{icon} {Math.abs(Number(v)).toFixed(1)}%</span>;
+        },
+      },
+      {
+        title: '만족도',
+        dataIndex: 'avgSatisfaction',
+        align: 'right',
+        width: 90,
+        render: (v) => (v == null ? '-' : Number(v).toFixed(2)),
+      },
+    ],
+    [],
+  );
+
+  return (
+    <Card
+      size="small"
+      style={{ marginBottom: 16 }}
+      title={
+        <Space>
+          <span>월간 통계</span>
+          <DatePicker
+            picker="month"
+            value={month}
+            onChange={(v) => v && setMonth(v)}
+            format="YYYY-MM"
+            allowClear={false}
+            size="small"
+          />
+        </Space>
+      }
+    >
+      <Row gutter={16} style={{ marginBottom: 16 }}>
+        <Col xs={24} sm={12} lg={6}>
+          <Statistic title="총 문의" value={stats?.totalInquiries ?? 0} suffix="건" />
+        </Col>
+        <Col xs={24} sm={12} lg={6}>
+          <Statistic title="해결 완료" value={stats?.resolvedCount ?? 0} suffix="건" />
+        </Col>
+        <Col xs={24} sm={12} lg={6}>
+          <Space direction="vertical" size={2} style={{ width: '100%' }}>
+            <span style={{ fontSize: 12, color: '#64748b' }}>해결률</span>
+            <Progress
+              percent={resRate != null ? Math.round(Number(resRate) * 100) : 0}
+              format={(p) => `${p}%`}
+              size="small"
+            />
+          </Space>
+        </Col>
+        <Col xs={24} sm={12} lg={6}>
+          <Space direction="vertical" size={2} style={{ width: '100%' }}>
+            <span style={{ fontSize: 12, color: '#64748b' }}>
+              AI 분류 정확도
+              <span style={{ color: '#94a3b8', marginLeft: 4 }}>
+                (재배정 {stats?.totalRoutingChanges ?? 0}건 중 오분류 {stats?.aiErrorCount ?? 0})
+              </span>
+            </span>
+            <Progress
+              percent={aiRate != null ? Math.round(Number(aiRate) * 100) : 0}
+              format={(p) => `${p}%`}
+              size="small"
+              status={aiRate != null && Number(aiRate) < 0.7 ? 'exception' : 'normal'}
+            />
+          </Space>
+        </Col>
+      </Row>
+
+      <Row gutter={16}>
+        <Col xs={24} lg={14}>
+          <h4 style={{ marginBottom: 8 }}>카테고리별 분포</h4>
+          {stats && stats.categories.length > 0 ? (
+            <Table
+              rowKey="category"
+              columns={catCols}
+              dataSource={stats.categories}
+              size="small"
+              pagination={false}
+            />
+          ) : (
+            <Empty description="이번 월 문의 없음" />
+          )}
+        </Col>
+        <Col xs={24} lg={10}>
+          <h4 style={{ marginBottom: 8 }}>장기 미해결 top 5</h4>
+          {stats && stats.unresolvedTop.length > 0 ? (
+            <Table
+              rowKey="csSeq"
+              size="small"
+              pagination={false}
+              columns={[
+                { title: '#', dataIndex: 'csSeq', width: 60 },
+                { title: '제목', dataIndex: 'inquiryTitle', ellipsis: true },
+                {
+                  title: '접수일',
+                  dataIndex: 'inquiryDate',
+                  width: 100,
+                  render: (v: string) => v?.slice(0, 10) ?? '-',
+                },
+              ]}
+              dataSource={stats.unresolvedTop}
+            />
+          ) : (
+            <Empty description="미해결 문의 없음" />
+          )}
+        </Col>
+      </Row>
+    </Card>
+  );
+}

--- a/apps/user-web/src/App.tsx
+++ b/apps/user-web/src/App.tsx
@@ -10,6 +10,9 @@ import { CartPage } from './pages/cart/CartPage';
 import { MyLecturePage } from './pages/mypage/MyLecturePage';
 import { ProfilePage } from './pages/mypage/ProfilePage';
 import { MockExamsPage } from './pages/mocktest/MockExamsPage';
+import { InquiryWritePage } from './pages/support/InquiryWritePage';
+import { MyInquiriesPage } from './pages/support/MyInquiriesPage';
+import { InquiryDetailPage } from './pages/support/InquiryDetailPage';
 
 export function App() {
   return (
@@ -31,6 +34,9 @@ export function App() {
         <Route path="mypage/profile" element={<ProfilePage />} />
         <Route path="mypage/mylecture" element={<MyLecturePage />} />
         <Route path="mocktest" element={<MockExamsPage />} />
+        <Route path="support/inquiry" element={<InquiryWritePage />} />
+        <Route path="support/inquiries" element={<MyInquiriesPage />} />
+        <Route path="support/inquiries/:csSeq" element={<InquiryDetailPage />} />
       </Route>
       <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>

--- a/apps/user-web/src/api/inquiries.ts
+++ b/apps/user-web/src/api/inquiries.ts
@@ -1,0 +1,61 @@
+/**
+ * 학생(USER) 1:1 문의 API — /api/user/inquiries/*
+ */
+import { unwrap } from '@academy/ui-core';
+import type { ApiResponse, PagedResponse } from '@academy/ui-core';
+import { apiClient } from './client';
+
+export interface Inquiry {
+  csSeq: number;
+  inquiryUserId: string;
+  inquiryName: string;
+  inquiryTitle: string;
+  bodyPreview?: string | null;
+  body?: string | null;
+  inquiryDate: string;
+  predictedCategory?: string | null;
+  predictedConfidence?: number | null;
+  classifiedByModel?: string | null;
+  actualCategory?: string | null;
+  answerBody?: string | null;
+  answeredBy?: string | null;
+  answeredAt?: string | null;
+  resolutionState: string;
+  userSatisfaction?: number | null;
+  rerouteCount?: number;
+}
+
+export interface RelatedItem {
+  cs_seq: number;
+  title: string;
+  answer_excerpt?: string | null;
+  similarity: number;
+  category?: string | null;
+}
+
+export async function createInquiry(payload: { title: string; body: string }): Promise<Inquiry> {
+  const res = await apiClient.post<ApiResponse<Inquiry>>('/inquiries', payload);
+  return unwrap<Inquiry>({ data: res.data });
+}
+
+export async function myInquiries(page = 1, size = 20): Promise<PagedResponse<Inquiry>> {
+  const res = await apiClient.get<ApiResponse<PagedResponse<Inquiry>>>(
+    '/inquiries',
+    { params: { page, size } },
+  );
+  return unwrap<PagedResponse<Inquiry>>({ data: res.data });
+}
+
+export async function myInquiryDetail(csSeq: number): Promise<Inquiry> {
+  const res = await apiClient.get<ApiResponse<Inquiry>>(`/inquiries/${csSeq}`);
+  return unwrap<Inquiry>({ data: res.data });
+}
+
+export async function suggestRelated(draftBody: string, topK = 3): Promise<RelatedItem[]> {
+  const res = await apiClient.post<ApiResponse<{ items: RelatedItem[] }>>(
+    '/inquiries/suggest-related',
+    { draftBody, topK },
+  );
+  const data = unwrap<{ items: RelatedItem[] }>({ data: res.data });
+  return data.items ?? [];
+}

--- a/apps/user-web/src/pages/UserShell.tsx
+++ b/apps/user-web/src/pages/UserShell.tsx
@@ -7,6 +7,8 @@ import {
   UserOutlined,
   PlayCircleOutlined,
   FileTextOutlined,
+  CustomerServiceOutlined,
+  EditOutlined,
 } from '@ant-design/icons';
 
 const menuGroups: SidebarMenuGroup[] = [
@@ -30,6 +32,14 @@ const menuGroups: SidebarMenuGroup[] = [
     items: [
       { key: 'cart', icon: <ShoppingCartOutlined />, label: '장바구니', to: '/cart' },
       { key: 'profile', icon: <UserOutlined />, label: '내 정보', to: '/mypage/profile' },
+    ],
+  },
+  {
+    key: 'support',
+    label: '고객센터',
+    items: [
+      { key: 'inquiry-write', icon: <EditOutlined />, label: '1:1 문의 작성', to: '/support/inquiry' },
+      { key: 'inquiries', icon: <CustomerServiceOutlined />, label: '내 문의 내역', to: '/support/inquiries' },
     ],
   },
 ];

--- a/apps/user-web/src/pages/support/InquiryDetailPage.tsx
+++ b/apps/user-web/src/pages/support/InquiryDetailPage.tsx
@@ -1,0 +1,94 @@
+import { useParams, useNavigate } from 'react-router-dom';
+import { Alert, Badge, Button, Card, Descriptions, Space, Tag, Typography } from 'antd';
+import { useQuery } from '@tanstack/react-query';
+import { PageContainer } from '@academy/ui-core';
+import { myInquiryDetail } from '../../api/inquiries';
+
+const CAT_LABELS: Record<string, string> = {
+  ACADEMIC: '학사·강의',
+  ORDER: '수강·결제·배송',
+  SYSTEM: '시스템·기술',
+  OTHER: '기타',
+};
+const STATE_LABELS: Record<string, { label: string; color: string }> = {
+  OPEN: { label: '대기', color: 'red' },
+  ANSWERED: { label: '답변완료', color: 'blue' },
+  RESOLVED: { label: '해결됨', color: 'green' },
+  CLOSED: { label: '종료', color: 'default' },
+};
+
+export function InquiryDetailPage() {
+  const { csSeq } = useParams();
+  const navigate = useNavigate();
+  const seqNum = Number(csSeq);
+
+  const q = useQuery({
+    queryKey: ['my-inquiry', seqNum],
+    queryFn: () => myInquiryDetail(seqNum),
+    enabled: !isNaN(seqNum),
+  });
+
+  const d = q.data;
+  const cat = d?.actualCategory || d?.predictedCategory;
+  const state = d ? STATE_LABELS[d.resolutionState] ?? { label: d.resolutionState, color: 'default' } : null;
+
+  return (
+    <PageContainer
+      title="문의 상세"
+      crumbs={[{ label: '고객센터' }, { label: '내 문의' }, { label: csSeq ?? '' }]}
+      extra={
+        <Space>
+          <Button onClick={() => navigate('/support/inquiries')}>목록</Button>
+          <Button type="primary" onClick={() => navigate('/support/inquiry')}>
+            새 문의 작성
+          </Button>
+        </Space>
+      }
+    >
+      {q.isError && <Alert type="error" message="문의를 불러올 수 없습니다." />}
+      {d && (
+        <Card>
+          <Descriptions column={2} bordered size="small" style={{ marginBottom: 16 }}>
+            <Descriptions.Item label="제목" span={2}>
+              {d.inquiryTitle}
+            </Descriptions.Item>
+            <Descriptions.Item label="접수일">{d.inquiryDate?.slice(0, 19).replace('T', ' ')}</Descriptions.Item>
+            <Descriptions.Item label="상태">
+              {state && <Badge color={state.color} text={state.label} />}
+            </Descriptions.Item>
+            <Descriptions.Item label="분류" span={2}>
+              {cat ? <Tag>{CAT_LABELS[cat] ?? cat}</Tag> : <Tag color="default">분류 중 (AI 처리)</Tag>}
+            </Descriptions.Item>
+          </Descriptions>
+
+          <Typography.Title level={5}>문의 내용</Typography.Title>
+          <div
+            style={{ padding: 12, background: '#f8fafc', borderRadius: 6, whiteSpace: 'pre-wrap' }}
+            dangerouslySetInnerHTML={{ __html: d.body || '-' }}
+          />
+
+          {d.answerBody ? (
+            <>
+              <Typography.Title level={5} style={{ marginTop: 20 }}>답변</Typography.Title>
+              <div
+                style={{ padding: 12, background: '#eff6ff', borderRadius: 6, whiteSpace: 'pre-wrap' }}
+                dangerouslySetInnerHTML={{ __html: d.answerBody }}
+              />
+              {d.answeredAt && (
+                <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                  {d.answeredAt.slice(0, 19).replace('T', ' ')} · {d.answeredBy ?? '-'}
+                </Typography.Text>
+              )}
+            </>
+          ) : (
+            <Alert
+              type="info"
+              style={{ marginTop: 20 }}
+              message={d.resolutionState === 'OPEN' ? '답변 대기 중입니다.' : '답변이 등록되지 않았습니다.'}
+            />
+          )}
+        </Card>
+      )}
+    </PageContainer>
+  );
+}

--- a/apps/user-web/src/pages/support/InquiryWritePage.tsx
+++ b/apps/user-web/src/pages/support/InquiryWritePage.tsx
@@ -1,0 +1,143 @@
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Alert, Button, Card, Empty, Form, Input, List, Space, Tag, Typography, message } from 'antd';
+import { useMutation } from '@tanstack/react-query';
+import { PageContainer } from '@academy/ui-core';
+import { createInquiry, suggestRelated, type RelatedItem } from '../../api/inquiries';
+
+const CAT_LABELS: Record<string, string> = {
+  ACADEMIC: '학사·강의',
+  ORDER: '수강·결제·배송',
+  SYSTEM: '시스템·기술',
+  OTHER: '기타',
+};
+
+export function InquiryWritePage() {
+  const navigate = useNavigate();
+  const [form] = Form.useForm<{ title: string; body: string }>();
+  const [draftBody, setDraftBody] = useState('');
+  const [suggestions, setSuggestions] = useState<RelatedItem[]>([]);
+  const [suggestLoading, setSuggestLoading] = useState(false);
+  const [suggestError, setSuggestError] = useState<string | null>(null);
+  const debounceRef = useRef<number | null>(null);
+
+  const createMut = useMutation({
+    mutationFn: createInquiry,
+    onSuccess: (d) => {
+      message.success('문의가 등록되었습니다. AI 분류 중입니다.');
+      navigate(`/support/inquiries/${d.csSeq}`);
+    },
+    onError: (e: Error) => message.error('등록 실패: ' + e.message),
+  });
+
+  // debounced suggest — 본문이 20자 이상이고 500ms 멈춤 후 호출
+  useEffect(() => {
+    if (debounceRef.current) window.clearTimeout(debounceRef.current);
+    if (draftBody.trim().length < 20) {
+      setSuggestions([]);
+      setSuggestError(null);
+      return;
+    }
+    debounceRef.current = window.setTimeout(async () => {
+      setSuggestLoading(true);
+      setSuggestError(null);
+      try {
+        const items = await suggestRelated(draftBody);
+        setSuggestions(items);
+      } catch (e) {
+        setSuggestError((e as Error).message);
+        setSuggestions([]);
+      } finally {
+        setSuggestLoading(false);
+      }
+    }, 500);
+  }, [draftBody]);
+
+  const goToRelated = (csSeq: number) => navigate(`/support/inquiries/${csSeq}`);
+
+  return (
+    <PageContainer title="1:1 문의 작성" crumbs={[{ label: '고객센터' }, { label: '1:1 문의 작성' }]}>
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 380px', gap: 20 }}>
+        <div>
+          <Alert
+            type="info"
+            showIcon
+            style={{ marginBottom: 16 }}
+            message="본문을 입력하면 AI 가 유사한 기존 답변을 우측에 추천합니다."
+            description="이미 답변이 있으면 등록 전에 바로 확인하실 수 있어요."
+          />
+          <Form<{ title: string; body: string }>
+            form={form}
+            layout="vertical"
+            onFinish={(v) => createMut.mutate(v)}
+            onValuesChange={(_, all) => setDraftBody(all.body ?? '')}
+          >
+            <Form.Item
+              name="title"
+              label="제목"
+              rules={[{ required: true, message: '제목을 입력하세요.' }, { max: 300 }]}
+            >
+              <Input placeholder="한 줄 요약" />
+            </Form.Item>
+            <Form.Item
+              name="body"
+              label="본문"
+              rules={[{ required: true, message: '본문을 입력하세요.' }]}
+            >
+              <Input.TextArea rows={12} placeholder="상황·오류 메시지·영상 URL 등 구체적으로 작성하면 답변이 빨라집니다." />
+            </Form.Item>
+            <Space>
+              <Button type="primary" htmlType="submit" loading={createMut.isPending}>
+                등록
+              </Button>
+              <Button onClick={() => navigate('/support/inquiries')}>내 문의 목록</Button>
+            </Space>
+          </Form>
+        </div>
+
+        <div>
+          <Card title="💡 관련 있는 문의" size="small" styles={{ header: { fontWeight: 600 } }}>
+            {suggestLoading && <Typography.Text type="secondary">검색 중…</Typography.Text>}
+            {suggestError && (
+              <Typography.Text type="warning" style={{ fontSize: 12 }}>
+                {suggestError}
+              </Typography.Text>
+            )}
+            {!suggestLoading && suggestions.length === 0 && !suggestError && (
+              <Empty
+                description={draftBody.trim().length < 20 ? '본문을 20자 이상 입력하면 추천 시작' : '유사 문의 없음'}
+                imageStyle={{ height: 40 }}
+              />
+            )}
+            <List
+              dataSource={suggestions}
+              renderItem={(it) => (
+                <List.Item
+                  style={{ cursor: 'pointer', padding: '8px 0' }}
+                  onClick={() => goToRelated(it.cs_seq)}
+                >
+                  <List.Item.Meta
+                    title={
+                      <Space size={4}>
+                        <Tag color="blue">{Math.round(it.similarity * 100)}%</Tag>
+                        {it.category && <Tag>{CAT_LABELS[it.category] ?? it.category}</Tag>}
+                        <span>{it.title}</span>
+                      </Space>
+                    }
+                    description={
+                      it.answer_excerpt && (
+                        <Typography.Paragraph ellipsis={{ rows: 2 }} style={{ fontSize: 12, marginBottom: 0 }}>
+                          {it.answer_excerpt.replace(/<[^>]*>/g, '')}
+                        </Typography.Paragraph>
+                      )
+                    }
+                  />
+                </List.Item>
+              )}
+            />
+          </Card>
+        </div>
+      </div>
+    </PageContainer>
+  );
+}

--- a/apps/user-web/src/pages/support/MyInquiriesPage.tsx
+++ b/apps/user-web/src/pages/support/MyInquiriesPage.tsx
@@ -1,0 +1,102 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Badge, Button, Space, Table, Tag } from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import { PlusOutlined, ReloadOutlined } from '@ant-design/icons';
+import { useQuery } from '@tanstack/react-query';
+import { PageContainer } from '@academy/ui-core';
+import { myInquiries, type Inquiry } from '../../api/inquiries';
+
+const CAT_LABELS: Record<string, string> = {
+  ACADEMIC: '학사·강의',
+  ORDER: '수강·결제·배송',
+  SYSTEM: '시스템·기술',
+  OTHER: '기타',
+};
+const STATE_LABELS: Record<string, { label: string; color: string }> = {
+  OPEN: { label: '대기', color: 'red' },
+  ANSWERED: { label: '답변완료', color: 'blue' },
+  RESOLVED: { label: '해결됨', color: 'green' },
+  CLOSED: { label: '종료', color: 'default' },
+};
+
+export function MyInquiriesPage() {
+  const navigate = useNavigate();
+  const [page, setPage] = useState(1);
+  const [size, setSize] = useState(20);
+
+  const q = useQuery({
+    queryKey: ['my-inquiries', page, size],
+    queryFn: () => myInquiries(page, size),
+    placeholderData: (p) => p,
+  });
+
+  const columns: ColumnsType<Inquiry> = [
+    { title: '#', dataIndex: 'csSeq', key: 'csSeq', width: 70 },
+    {
+      title: '제목',
+      dataIndex: 'inquiryTitle',
+      key: 'inquiryTitle',
+      ellipsis: true,
+      render: (v, row) => <a onClick={() => navigate(`/support/inquiries/${row.csSeq}`)}>{v}</a>,
+    },
+    {
+      title: '분류',
+      key: 'category',
+      width: 130,
+      render: (_, row) => {
+        const cat = row.actualCategory || row.predictedCategory;
+        return cat ? <Tag>{CAT_LABELS[cat] ?? cat}</Tag> : <Tag color="default">분류 중</Tag>;
+      },
+    },
+    {
+      title: '상태',
+      dataIndex: 'resolutionState',
+      key: 'resolutionState',
+      width: 100,
+      render: (v: string) => {
+        const s = STATE_LABELS[v] ?? { label: v, color: 'default' };
+        return <Badge color={s.color} text={s.label} />;
+      },
+    },
+    {
+      title: '접수일',
+      dataIndex: 'inquiryDate',
+      key: 'inquiryDate',
+      width: 110,
+      render: (v: string) => v?.slice(0, 10) ?? '-',
+    },
+  ];
+
+  return (
+    <PageContainer
+      title="내 문의 내역"
+      crumbs={[{ label: '고객센터' }, { label: '내 문의' }]}
+      extra={
+        <Space>
+          <Button icon={<ReloadOutlined />} onClick={() => q.refetch()}>
+            새로고침
+          </Button>
+          <Button type="primary" icon={<PlusOutlined />} onClick={() => navigate('/support/inquiry')}>
+            새 문의 작성
+          </Button>
+        </Space>
+      }
+    >
+      <Table<Inquiry>
+        rowKey="csSeq"
+        columns={columns}
+        dataSource={q.data?.items ?? []}
+        loading={q.isFetching}
+        size="middle"
+        pagination={{
+          current: page,
+          pageSize: size,
+          total: Number(q.data?.totalItems ?? 0),
+          onChange: (p, s) => { setPage(p); setSize(s); },
+          showSizeChanger: true,
+        }}
+      />
+    </PageContainer>
+  );
+}

--- a/backend/src/main/java/com/academy/AcademyApplication.java
+++ b/backend/src/main/java/com/academy/AcademyApplication.java
@@ -9,8 +9,10 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
+@EnableAsync
 public class AcademyApplication {
 
 	@Value("${server.port:8080}")

--- a/backend/src/main/java/com/academy/inquiry/InquiryApi.java
+++ b/backend/src/main/java/com/academy/inquiry/InquiryApi.java
@@ -94,6 +94,14 @@ public class InquiryApi {
         return ResponseEntity.ok(ApiResponse.ok(d));
     }
 
+    @Operation(summary = "월간 통계 (카테고리 트렌드·AI 정확도·미해결 top)")
+    @GetMapping("/stats")
+    public ApiResponse<com.academy.inquiry.dto.MonthlyStatsResponse> stats(
+        @RequestParam(name = "ym") String yearMonth
+    ) {
+        return ApiResponse.ok(service.monthlyStats(yearMonth));
+    }
+
     @Operation(summary = "유사 문의 추천 (agent 호출)")
     @GetMapping("/{csSeq}/related")
     public ResponseEntity<ApiResponse<InquiryAgentClient.SuggestResponse>> related(@PathVariable long csSeq) {

--- a/backend/src/main/java/com/academy/inquiry/UserInquiryApi.java
+++ b/backend/src/main/java/com/academy/inquiry/UserInquiryApi.java
@@ -1,0 +1,85 @@
+package com.academy.inquiry;
+
+import com.academy.inquiry.dto.InquiryCreateRequest;
+import com.academy.inquiry.dto.InquiryDto;
+import com.academy.inquiry.dto.SuggestRequest;
+import com.academy.inquiry.service.InquiryAgentClient;
+import com.academy.inquiry.service.InquiryService;
+import com.academy.shared.common.ApiResponse;
+import com.academy.shared.common.PagedResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 학생(USER) 전용 1:1 문의 작성·조회. Phase D.
+ *
+ * <p>SecurityConfig 가 {@code /api/user/**} 을 hasRole(USER) 로 보호.
+ * 본인 것만 조회 가능 (selectDetail owner check).
+ */
+@RestController
+@RequestMapping("/api/user/inquiries")
+@Tag(name = "User Inquiries", description = "학생 1:1 문의 작성·조회")
+public class UserInquiryApi {
+
+    private final InquiryService service;
+
+    public UserInquiryApi(InquiryService service) {
+        this.service = service;
+    }
+
+    @Operation(summary = "문의 신규 등록 (자동 AI 분류 async 트리거)")
+    @PostMapping
+    public ResponseEntity<ApiResponse<InquiryDto>> create(
+        @Valid @RequestBody InquiryCreateRequest req,
+        Authentication auth
+    ) {
+        String userId = String.valueOf(auth.getPrincipal());
+        InquiryDto d = service.createByUser(userId, userId, req);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(d));
+    }
+
+    @Operation(summary = "내 문의 목록")
+    @GetMapping
+    public ApiResponse<PagedResponse<InquiryDto>> myList(
+        @RequestParam(required = false, defaultValue = "1") int page,
+        @RequestParam(required = false, defaultValue = "20") int size,
+        Authentication auth
+    ) {
+        String userId = String.valueOf(auth.getPrincipal());
+        return ApiResponse.ok(service.myList(userId, page, size));
+    }
+
+    @Operation(summary = "내 문의 상세")
+    @GetMapping("/{csSeq}")
+    public ResponseEntity<ApiResponse<InquiryDto>> myDetail(
+        @PathVariable long csSeq,
+        Authentication auth
+    ) {
+        String userId = String.valueOf(auth.getPrincipal());
+        InquiryDto d = service.myDetail(userId, csSeq);
+        if (d == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiResponse.fail("INQUIRY_404", "문의를 찾을 수 없습니다."));
+        }
+        return ResponseEntity.ok(ApiResponse.ok(d));
+    }
+
+    @Operation(summary = "작성 중 유사문의 추천 (debounced agent 호출)")
+    @PostMapping("/suggest-related")
+    public ResponseEntity<ApiResponse<InquiryAgentClient.SuggestResponse>> suggest(
+        @Valid @RequestBody SuggestRequest req
+    ) {
+        try {
+            var r = service.suggestForDraft(req.draftBody(), req.topK());
+            return ResponseEntity.ok(ApiResponse.ok(r));
+        } catch (InquiryAgentClient.AgentException e) {
+            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                .body(ApiResponse.fail("AGENT_UNAVAILABLE", e.getMessage()));
+        }
+    }
+}

--- a/backend/src/main/java/com/academy/inquiry/dto/InquiryCreateRequest.java
+++ b/backend/src/main/java/com/academy/inquiry/dto/InquiryCreateRequest.java
@@ -1,0 +1,10 @@
+package com.academy.inquiry.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record InquiryCreateRequest(
+    @NotBlank @Size(max = 300) String title,
+    @NotBlank String body,
+    String inquiryName  // optional override; 기본은 사용자 이름
+) {}

--- a/backend/src/main/java/com/academy/inquiry/dto/MonthlyStatsResponse.java
+++ b/backend/src/main/java/com/academy/inquiry/dto/MonthlyStatsResponse.java
@@ -1,0 +1,29 @@
+package com.academy.inquiry.dto;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * 월간 통계 응답. 운영자 대시보드용.
+ */
+public record MonthlyStatsResponse(
+    String yearMonth,
+    List<CategoryStat> categories,
+    long totalInquiries,
+    long resolvedCount,
+    BigDecimal resolutionRate,
+    BigDecimal aiAccuracyRate,   // 1 - (ai_error_count / total_routing)
+    long aiErrorCount,
+    long totalRoutingChanges,
+    List<InquiryDto> unresolvedTop
+) {
+    public record CategoryStat(
+        String category,
+        long totalCount,
+        long resolvedCount,
+        long prevMonthCount,
+        BigDecimal momDeltaPct,
+        boolean decreasing,
+        BigDecimal avgSatisfaction
+    ) {}
+}

--- a/backend/src/main/java/com/academy/inquiry/dto/SuggestRequest.java
+++ b/backend/src/main/java/com/academy/inquiry/dto/SuggestRequest.java
@@ -1,0 +1,8 @@
+package com.academy.inquiry.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record SuggestRequest(
+    @NotBlank String draftBody,
+    Integer topK
+) {}

--- a/backend/src/main/java/com/academy/inquiry/service/InquiryService.java
+++ b/backend/src/main/java/com/academy/inquiry/service/InquiryService.java
@@ -1,20 +1,28 @@
 package com.academy.inquiry.service;
 
 import com.academy.inquiry.dto.AnswerRequest;
+import com.academy.inquiry.dto.InquiryCreateRequest;
 import com.academy.inquiry.dto.InquiryDto;
 import com.academy.inquiry.dto.InquirySearchRequest;
+import com.academy.inquiry.dto.MonthlyStatsResponse;
 import com.academy.inquiry.dto.ReassignRequest;
 import com.academy.mapper.InquiryMapper;
 import com.academy.shared.common.PagedResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Service
 public class InquiryService implements Serializable {
@@ -96,6 +104,137 @@ public class InquiryService implements Serializable {
         InquiryDto d = mapper.selectDetail(csSeq);
         if (d == null) return null;
         return agent.suggestRelated(d.body(), 3);
+    }
+
+    // ==================================================================
+    // Phase D — 사용자 작성·본인 목록·유사추천·통계·async 분류
+    // ==================================================================
+
+    /** 사용자 신규 문의 등록 후 async 분류 트리거. */
+    @Transactional
+    public InquiryDto createByUser(String userId, String userName, InquiryCreateRequest req) {
+        long csSeq = 0;
+        // MyBatis useGeneratedKeys — 삽입 후 키 채워짐
+        var params = new HashMap<String, Object>();
+        params.put("userId", userId);
+        params.put("name", req.inquiryName() != null && !req.inquiryName().isBlank()
+            ? req.inquiryName() : userName);
+        params.put("title", req.title());
+        params.put("body", req.body());
+
+        // 직접 mapper 메서드 호출 — return type 이 insert id
+        mapper.insertInquiry(userId,
+            req.inquiryName() != null && !req.inquiryName().isBlank()
+                ? req.inquiryName() : userName,
+            req.title(), req.body());
+        // Mapper 의 useGeneratedKeys=true 가 첫 번째 Long 반환을 채움. MyBatis 는 이를
+        // selectKey 없이 안전하게 리턴하려면 trick 필요. 간단히 재조회로 대체:
+        InquiryDto created = mapper.selectMyList(userId, 1, 0).stream()
+            .findFirst().orElse(null);
+
+        if (created != null) {
+            classifyAsync(created.csSeq());
+        }
+        return created;
+    }
+
+    /** 비동기 분류 — 사용자 응답 블로킹 방지. 실패 시 로그만. */
+    @Async
+    public void classifyAsync(long csSeq) {
+        try {
+            classifyNow(csSeq);
+        } catch (Exception e) {
+            log.warn("async classify 실패 cs_seq={}: {}", csSeq, e.getMessage());
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public PagedResponse<InquiryDto> myList(String userId, int page, int size) {
+        int p = Math.max(1, page);
+        int s = Math.max(1, Math.min(100, size));
+        int offset = (p - 1) * s;
+        List<InquiryDto> items = mapper.selectMyList(userId, s, offset);
+        long total = mapper.selectMyCount(userId);
+        return PagedResponse.of(items, p, s, total);
+    }
+
+    /** 본인 문의 상세. 소유자 아니면 null. */
+    @Transactional(readOnly = true)
+    public InquiryDto myDetail(String userId, long csSeq) {
+        InquiryDto d = mapper.selectDetail(csSeq);
+        if (d == null || !userId.equals(d.inquiryUserId())) return null;
+        return d;
+    }
+
+    /** 문의 작성 중 유사문의 추천 (agent 호출). 로그인 사용자 전용. */
+    public InquiryAgentClient.SuggestResponse suggestForDraft(String draftBody, Integer topK)
+        throws InquiryAgentClient.AgentException {
+        return agent.suggestRelated(draftBody, topK == null ? 3 : topK);
+    }
+
+    /** 운영자 대시보드 월간 통계. */
+    @Transactional(readOnly = true)
+    public MonthlyStatsResponse monthlyStats(String ym) {
+        List<Map<String, Object>> curr = mapper.selectMonthlyStats(ym);
+
+        YearMonth y = YearMonth.parse(ym);
+        String prevYm = y.minusMonths(1).toString();
+        Map<String, Long> prev = new HashMap<>();
+        for (Map<String, Object> r : mapper.selectMonthlyStats(prevYm)) {
+            prev.put(String.valueOf(r.get("category")), toLong(r.get("totalCount")));
+        }
+
+        List<MonthlyStatsResponse.CategoryStat> cats = new ArrayList<>();
+        long total = 0;
+        long resolved = 0;
+        for (Map<String, Object> r : curr) {
+            String cat = String.valueOf(r.get("category"));
+            long cnt = toLong(r.get("totalCount"));
+            long res = toLong(r.get("resolvedCount"));
+            BigDecimal sat = toDecimal(r.get("avgSatisfaction"));
+            long prevCnt = prev.getOrDefault(cat, 0L);
+            BigDecimal delta = null;
+            boolean decreasing = false;
+            if (prevCnt > 0) {
+                delta = BigDecimal.valueOf(cnt - prevCnt)
+                    .multiply(BigDecimal.valueOf(100))
+                    .divide(BigDecimal.valueOf(prevCnt), 2, RoundingMode.HALF_UP);
+                decreasing = delta.signum() < 0;
+            }
+            cats.add(new MonthlyStatsResponse.CategoryStat(cat, cnt, res, prevCnt, delta, decreasing, sat));
+            total += cnt;
+            resolved += res;
+        }
+
+        Map<String, Object> routing = mapper.selectRoutingStats(ym);
+        long totalLog = routing == null ? 0 : toLong(routing.get("totalLog"));
+        long aiErr = routing == null ? 0 : toLong(routing.get("aiErrorCount"));
+        BigDecimal aiAccuracy = totalLog > 0
+            ? BigDecimal.valueOf(totalLog - aiErr).divide(BigDecimal.valueOf(totalLog), 4, RoundingMode.HALF_UP)
+            : null;
+        BigDecimal resRate = total > 0
+            ? BigDecimal.valueOf(resolved).divide(BigDecimal.valueOf(total), 4, RoundingMode.HALF_UP)
+            : null;
+
+        List<InquiryDto> unresolvedTop = mapper.selectUnresolvedTop(5);
+
+        return new MonthlyStatsResponse(
+            ym, cats, total, resolved, resRate,
+            aiAccuracy, aiErr, totalLog, unresolvedTop
+        );
+    }
+
+    private static long toLong(Object o) {
+        if (o == null) return 0;
+        if (o instanceof Number n) return n.longValue();
+        try { return Long.parseLong(o.toString()); } catch (Exception e) { return 0; }
+    }
+
+    private static BigDecimal toDecimal(Object o) {
+        if (o == null) return null;
+        if (o instanceof BigDecimal b) return b;
+        if (o instanceof Number n) return BigDecimal.valueOf(n.doubleValue());
+        try { return new BigDecimal(o.toString()); } catch (Exception e) { return null; }
     }
 
     private static String truncate(String s, int max) {

--- a/backend/src/main/java/com/academy/mapper/InquiryMapper.java
+++ b/backend/src/main/java/com/academy/mapper/InquiryMapper.java
@@ -60,4 +60,30 @@ public interface InquiryMapper {
         @Param("latencyMs") Integer latencyMs,
         @Param("rawOutput") String rawOutput
     );
+
+    /** 사용자 문의 신규 등록. generated cs_seq 반환 위해 VO 대신 Long 사용시 useGeneratedKeys 필요. */
+    long insertInquiry(
+        @Param("userId") String userId,
+        @Param("name") String name,
+        @Param("title") String title,
+        @Param("body") String body
+    );
+
+    /** 본인이 등록한 문의 목록 (inquiry_user_id = userId). */
+    List<InquiryDto> selectMyList(
+        @Param("userId") String userId,
+        @Param("limit") int limit,
+        @Param("offset") int offset
+    );
+
+    long selectMyCount(@Param("userId") String userId);
+
+    /** 특정 YYYY-MM 의 카테고리별 집계. COALESCE(actual, predicted). */
+    List<java.util.Map<String, Object>> selectMonthlyStats(@Param("ym") String ym);
+
+    /** AI 오분류 건수 / 전체 재배정 건수 — 정확도 지표. */
+    java.util.Map<String, Object> selectRoutingStats(@Param("ym") String ym);
+
+    /** 미해결 문의 top-N (접수 오래된 순). */
+    List<InquiryDto> selectUnresolvedTop(@Param("limit") int limit);
 }

--- a/backend/src/main/resources/mapper/inquiry.xml
+++ b/backend/src/main/resources/mapper/inquiry.xml
@@ -131,4 +131,102 @@
         )
     </insert>
 
+    <!-- ============================================================== -->
+    <!-- Phase D 추가 — 사용자 문의 작성·본인 목록·통계                   -->
+    <!-- ============================================================== -->
+
+    <insert id="insertInquiry" useGeneratedKeys="true" keyProperty="csSeq">
+        INSERT INTO acm_board_cs (
+            inquiry_user_id, inquiry_name,
+            inquiry_title, inquiry_body, inquiry_date,
+            resolution_state, reg_dt
+        ) VALUES (
+            #{userId}, #{name},
+            #{title}, #{body}, NOW(),
+            'OPEN', NOW()
+        )
+    </insert>
+
+    <select id="selectMyList" resultType="com.academy.inquiry.dto.InquiryDto">
+        SELECT
+            cs_seq                AS csSeq,
+            inquiry_user_id       AS inquiryUserId,
+            inquiry_name          AS inquiryName,
+            inquiry_title         AS inquiryTitle,
+            LEFT(inquiry_body, 200)  AS bodyPreview,
+            NULL                  AS body,
+            inquiry_date          AS inquiryDate,
+            predicted_category    AS predictedCategory,
+            predicted_confidence  AS predictedConfidence,
+            classified_by_model   AS classifiedByModel,
+            classified_at         AS classifiedAt,
+            actual_category       AS actualCategory,
+            assigned_to           AS assignedTo,
+            reroute_count         AS rerouteCount,
+            NULL                  AS answerBody,
+            answered_by           AS answeredBy,
+            answered_at           AS answeredAt,
+            resolution_state      AS resolutionState,
+            user_satisfaction     AS userSatisfaction
+        FROM acm_board_cs
+        WHERE inquiry_user_id = #{userId}
+          AND is_deleted = 'N'
+        ORDER BY inquiry_date DESC, cs_seq DESC
+        LIMIT #{limit} OFFSET #{offset}
+    </select>
+
+    <select id="selectMyCount" resultType="long">
+        SELECT COUNT(*) FROM acm_board_cs
+        WHERE inquiry_user_id = #{userId}
+          AND is_deleted = 'N'
+    </select>
+
+    <select id="selectMonthlyStats" resultType="java.util.Map">
+        SELECT
+            COALESCE(actual_category, predicted_category, 'OTHER') AS category,
+            COUNT(*) AS totalCount,
+            SUM(CASE WHEN resolution_state IN ('ANSWERED','RESOLVED') THEN 1 ELSE 0 END) AS resolvedCount,
+            AVG(user_satisfaction) AS avgSatisfaction
+        FROM acm_board_cs
+        WHERE DATE_FORMAT(inquiry_date, '%Y-%m') = #{ym}
+          AND is_deleted = 'N'
+        GROUP BY category
+    </select>
+
+    <select id="selectRoutingStats" resultType="java.util.Map">
+        SELECT
+            COUNT(*) AS totalLog,
+            SUM(CASE WHEN is_ai_error = 'Y' THEN 1 ELSE 0 END) AS aiErrorCount
+        FROM acm_inquiry_routing_log
+        WHERE DATE_FORMAT(changed_at, '%Y-%m') = #{ym}
+    </select>
+
+    <select id="selectUnresolvedTop" resultType="com.academy.inquiry.dto.InquiryDto">
+        SELECT
+            cs_seq                AS csSeq,
+            inquiry_user_id       AS inquiryUserId,
+            inquiry_name          AS inquiryName,
+            inquiry_title         AS inquiryTitle,
+            LEFT(inquiry_body, 100)  AS bodyPreview,
+            NULL                  AS body,
+            inquiry_date          AS inquiryDate,
+            predicted_category    AS predictedCategory,
+            predicted_confidence  AS predictedConfidence,
+            classified_by_model   AS classifiedByModel,
+            classified_at         AS classifiedAt,
+            actual_category       AS actualCategory,
+            assigned_to           AS assignedTo,
+            reroute_count         AS rerouteCount,
+            NULL                  AS answerBody,
+            answered_by           AS answeredBy,
+            answered_at           AS answeredAt,
+            resolution_state      AS resolutionState,
+            user_satisfaction     AS userSatisfaction
+        FROM acm_board_cs
+        WHERE is_deleted = 'N'
+          AND resolution_state = 'OPEN'
+        ORDER BY inquiry_date ASC
+        LIMIT #{limit}
+    </select>
+
 </mapper>


### PR DESCRIPTION
## Summary

**Phase D of CS_INQUIRY_AI_PLAN**. 학생 자가해결 + 운영자 인사이트.

## Backend

- \`POST /api/user/inquiries\` — 신규 (async 분류 트리거)
- \`GET  /api/user/inquiries\` — 본인 목록
- \`GET  /api/user/inquiries/{seq}\` — 본인 상세
- \`POST /api/user/inquiries/suggest-related\` — debounced agent 호출
- \`GET  /api/inquiries/stats?ym=YYYY-MM\` — 운영자 월간 통계

## user-web

- **/support/inquiry** — 작성 폼 + 우측 실시간 유사문의 Card (20자+ 500ms debounce)
- **/support/inquiries** — 내 문의 목록
- **/support/inquiries/:seq** — 상세·답변
- 사이드바 "고객센터" 그룹 (2 메뉴)

## admin-web

- \`InquiriesPage\` 상단에 \`InquiryStatsPanel\`:
  - 월 선택 + KPI 4개 (총/해결/해결률/AI정확도)
  - 카테고리별 분포 (MoM delta, 하락 녹색)
  - 장기 미해결 top-5

## Test plan

- [ ] ci-main 통과
- [ ] deploy 후 user-web /support/inquiry 화면 로드
- [ ] 본문 20자+ 입력시 우측 유사문의 panel 에 추천 표시 (agent /suggest-related 호출)
- [ ] POST /api/user/inquiries → 201 → async 분류 (cs_seq 로 detail 열면 몇초 후 predicted_category 채워짐)
- [ ] admin /support/inquiries → 상단 통계 카드 + 카테고리 분포 테이블 + 미해결 top5