### PR TITLE
fix: insertInquiry useGeneratedKeys 제거 + user nginx auth/shared 라우팅

### DIFF
--- a/backend/src/main/java/com/academy/mapper/InquiryMapper.java
+++ b/backend/src/main/java/com/academy/mapper/InquiryMapper.java
@@ -61,8 +61,8 @@ public interface InquiryMapper {
         @Param("rawOutput") String rawOutput
     );
 
-    /** 사용자 문의 신규 등록. generated cs_seq 반환 위해 VO 대신 Long 사용시 useGeneratedKeys 필요. */
-    long insertInquiry(
+    /** 사용자 문의 신규 등록. int = affected rows. Service 에서 selectMyList 로 최신 행 재조회. */
+    int insertInquiry(
         @Param("userId") String userId,
         @Param("name") String name,
         @Param("title") String title,

--- a/backend/src/main/resources/mapper/inquiry.xml
+++ b/backend/src/main/resources/mapper/inquiry.xml
@@ -135,7 +135,10 @@
     <!-- Phase D 추가 — 사용자 문의 작성·본인 목록·통계                   -->
     <!-- ============================================================== -->
 
-    <insert id="insertInquiry" useGeneratedKeys="true" keyProperty="csSeq">
+    <!-- useGeneratedKeys + keyProperty 는 @Param 기반 mapper 에 쓰면 Jdbc3KeyGenerator 가
+         parameter 를 Map/POJO 로 가정하고 BeanWrapper NPE. Service 에서 selectMyList(limit=1)
+         로 재조회하므로 생성 키 반환 불필요. -->
+    <insert id="insertInquiry">
         INSERT INTO acm_board_cs (
             inquiry_user_id, inquiry_name,
             inquiry_title, inquiry_body, inquiry_date,

--- a/infra/nginx/academy.conf
+++ b/infra/nginx/academy.conf
@@ -93,6 +93,19 @@ server {
         include /etc/nginx/conf.d/proxy-params.conf;
     }
 
+    # User Auth — /api/auth/** 는 shared 엔드포인트 (/api/auth 그대로). user 로 rewrite 금지.
+    # /api/ 일반 location 보다 ^~ 가 우선.
+    location ^~ /api/auth/ {
+        proxy_pass http://host.docker.internal:9001/api/auth/;
+        include /etc/nginx/conf.d/proxy-params.conf;
+    }
+
+    # User Shared API — 공통 /api/shared/**
+    location ^~ /api/shared/ {
+        proxy_pass http://host.docker.internal:9001/api/shared/;
+        include /etc/nginx/conf.d/proxy-params.conf;
+    }
+
     # User Backend API
     #   /api/xyz → :9001/api/user/xyz
     location /api/ {


### PR DESCRIPTION
Phase D E2E 테스트 중 발견한 2건 hotfix: (1) MyBatis Jdbc3KeyGenerator NPE (2) user-web /api/auth signup 401.