### PR TITLE
feat(inquiry): legacy TB_BOARD_CS + 신규 tb_inquiry 통합 운영 — v_inquiry view 도입

### DIFF
--- a/apps/admin-web/src/api/inquiries.ts
+++ b/apps/admin-web/src/api/inquiries.ts
@@ -11,8 +11,11 @@ import { apiClient } from './client';
 export type InquiryCategory = 'ACADEMIC' | 'ORDER' | 'SYSTEM' | 'OTHER';
 export type ResolutionState = 'OPEN' | 'ANSWERED' | 'RESOLVED' | 'CLOSED';
 
+export type InquirySource = 'L' | 'N';
+
 export interface Inquiry {
-  csSeq: number;
+  source: InquirySource;
+  csSeq: string;
   inquiryUserId: string;
   inquiryName: string;
   inquiryTitle: string;
@@ -61,38 +64,43 @@ export async function listInquiries(params: InquirySearch): Promise<PagedRespons
   return unwrap<PagedResponse<Inquiry>>({ data: res.data });
 }
 
-export async function getInquiryDetail(csSeq: number): Promise<Inquiry> {
-  const res = await apiClient.get<ApiResponse<Inquiry>>(`/inquiries/${csSeq}`);
+export async function getInquiryDetail(csSeq: string): Promise<Inquiry> {
+  const res = await apiClient.get<ApiResponse<Inquiry>>(`/inquiries/${encodeURIComponent(csSeq)}`);
   return unwrap<Inquiry>({ data: res.data });
 }
 
-export async function classifyNow(csSeq: number): Promise<Inquiry> {
-  const res = await apiClient.post<ApiResponse<Inquiry>>(`/inquiries/${csSeq}/classify`);
+export async function classifyNow(csSeq: string): Promise<Inquiry> {
+  const res = await apiClient.post<ApiResponse<Inquiry>>(`/inquiries/${encodeURIComponent(csSeq)}/classify`);
   return unwrap<Inquiry>({ data: res.data });
 }
 
 export async function postAnswer(
-  csSeq: number,
+  csSeq: string,
   answerBody: string,
   resolutionState?: ResolutionState,
 ): Promise<Inquiry> {
-  const res = await apiClient.post<ApiResponse<Inquiry>>(`/inquiries/${csSeq}/answer`, {
-    answerBody,
-    resolutionState,
-  });
+  const res = await apiClient.post<ApiResponse<Inquiry>>(
+    `/inquiries/${encodeURIComponent(csSeq)}/answer`,
+    { answerBody, resolutionState },
+  );
   return unwrap<Inquiry>({ data: res.data });
 }
 
 export async function reassignInquiry(
-  csSeq: number,
+  csSeq: string,
   payload: { toCategory: string; toUser: string; reason?: string; isAiError?: boolean },
 ): Promise<Inquiry> {
-  const res = await apiClient.post<ApiResponse<Inquiry>>(`/inquiries/${csSeq}/reassign`, payload);
+  const res = await apiClient.post<ApiResponse<Inquiry>>(
+    `/inquiries/${encodeURIComponent(csSeq)}/reassign`,
+    payload,
+  );
   return unwrap<Inquiry>({ data: res.data });
 }
 
-export async function getRelated(csSeq: number): Promise<SuggestResponse> {
-  const res = await apiClient.get<ApiResponse<SuggestResponse>>(`/inquiries/${csSeq}/related`);
+export async function getRelated(csSeq: string): Promise<SuggestResponse> {
+  const res = await apiClient.get<ApiResponse<SuggestResponse>>(
+    `/inquiries/${encodeURIComponent(csSeq)}/related`,
+  );
   return unwrap<SuggestResponse>({ data: res.data });
 }
 

--- a/apps/admin-web/src/pages/inquiries/InquiriesPage.tsx
+++ b/apps/admin-web/src/pages/inquiries/InquiriesPage.tsx
@@ -58,7 +58,7 @@ export function InquiriesPage() {
   const [filter, setFilter] = useState<InquirySearch>({});
   const [page, setPage] = useState(1);
   const [size, setSize] = useState(20);
-  const [detailTarget, setDetailTarget] = useState<number | null>(null);
+  const [detailTarget, setDetailTarget] = useState<string | null>(null);
   const [reassignOpen, setReassignOpen] = useState(false);
 
   const params: InquirySearch = useMemo(
@@ -90,21 +90,34 @@ export function InquiriesPage() {
   });
 
   const answerMut = useMutation({
-    mutationFn: (v: { csSeq: number; answerBody: string; state?: ResolutionState }) =>
+    mutationFn: (v: { csSeq: string; answerBody: string; state?: ResolutionState }) =>
       postAnswer(v.csSeq, v.answerBody, v.state),
     onSuccess: () => { message.success('답변 저장'); answerForm.resetFields(['answerBody']); invalidate(); },
     onError: (e: Error) => message.error(e.message),
   });
 
   const reassignMut = useMutation({
-    mutationFn: (v: { csSeq: number; toCategory: string; toUser: string; reason?: string; isAiError?: boolean }) =>
+    mutationFn: (v: { csSeq: string; toCategory: string; toUser: string; reason?: string; isAiError?: boolean }) =>
       reassignInquiry(v.csSeq, v),
     onSuccess: () => { message.success('재배정 완료'); setReassignOpen(false); reassignForm.resetFields(); invalidate(); },
     onError: (e: Error) => message.error(e.message),
   });
 
   const columns: ColumnsType<Inquiry> = [
-    { title: '#', dataIndex: 'csSeq', key: 'csSeq', width: 70 },
+    {
+      title: '#',
+      dataIndex: 'csSeq',
+      key: 'csSeq',
+      width: 130,
+      render: (v: string, row) => (
+        <Space size={4}>
+          <Tag color={row.source === 'L' ? 'default' : 'green'} style={{ marginInlineEnd: 0 }}>
+            {row.source === 'L' ? 'Legacy' : 'New'}
+          </Tag>
+          <span>{v}</span>
+        </Space>
+      ),
+    },
     {
       title: '제목',
       dataIndex: 'inquiryTitle',
@@ -254,7 +267,7 @@ export function InquiriesPage() {
         destroyOnClose
         loading={detail.isLoading}
         extra={
-          target && (
+          target && target.source === 'N' && (
             <Space>
               <Button
                 icon={<ThunderboltOutlined />}
@@ -337,35 +350,47 @@ export function InquiriesPage() {
               </>
             )}
 
-            <h4 style={{ marginTop: 20 }}>답변 {target.answerBody ? '수정' : '등록'}</h4>
-            <Form
-              form={answerForm}
-              layout="vertical"
-              onFinish={(v) =>
-                answerMut.mutate({
-                  csSeq: target.csSeq,
-                  answerBody: v.answerBody,
-                  state: v.resolutionState,
-                })
-              }
-            >
-              <Form.Item name="answerBody" rules={[{ required: true, message: '답변 본문을 입력하세요.' }]}>
-                <Input.TextArea rows={6} placeholder="답변 내용 (Markdown/HTML)" />
-              </Form.Item>
-              <Form.Item name="resolutionState" label="처리 상태" initialValue="ANSWERED">
-                <Select
-                  style={{ width: 200 }}
-                  options={[
-                    { value: 'ANSWERED', label: '답변 완료' },
-                    { value: 'RESOLVED', label: '해결됨' },
-                    { value: 'CLOSED', label: '종료' },
-                  ]}
-                />
-              </Form.Item>
-              <Button type="primary" htmlType="submit" loading={answerMut.isPending}>
-                답변 저장
-              </Button>
-            </Form>
+            {target.source === 'N' ? (
+              <>
+                <h4 style={{ marginTop: 20 }}>답변 {target.answerBody ? '수정' : '등록'}</h4>
+                <Form
+                  form={answerForm}
+                  layout="vertical"
+                  onFinish={(v) =>
+                    answerMut.mutate({
+                      csSeq: target.csSeq,
+                      answerBody: v.answerBody,
+                      state: v.resolutionState,
+                    })
+                  }
+                >
+                  <Form.Item name="answerBody" rules={[{ required: true, message: '답변 본문을 입력하세요.' }]}>
+                    <Input.TextArea rows={6} placeholder="답변 내용 (Markdown/HTML)" />
+                  </Form.Item>
+                  <Form.Item name="resolutionState" label="처리 상태" initialValue="ANSWERED">
+                    <Select
+                      style={{ width: 200 }}
+                      options={[
+                        { value: 'ANSWERED', label: '답변 완료' },
+                        { value: 'RESOLVED', label: '해결됨' },
+                        { value: 'CLOSED', label: '종료' },
+                      ]}
+                    />
+                  </Form.Item>
+                  <Button type="primary" htmlType="submit" loading={answerMut.isPending}>
+                    답변 저장
+                  </Button>
+                </Form>
+              </>
+            ) : (
+              <Alert
+                type="warning"
+                showIcon
+                style={{ marginTop: 20 }}
+                message="Legacy 아카이브 — 읽기 전용"
+                description="원본 TB_BOARD_CS 데이터입니다. 답변·재배정·재분류는 신규 문의에서만 가능합니다."
+              />
+            )}
           </>
         )}
       </Drawer>

--- a/apps/user-web/src/api/inquiries.ts
+++ b/apps/user-web/src/api/inquiries.ts
@@ -5,8 +5,11 @@ import { unwrap } from '@academy/ui-core';
 import type { ApiResponse, PagedResponse } from '@academy/ui-core';
 import { apiClient } from './client';
 
+export type InquirySource = 'L' | 'N';
+
 export interface Inquiry {
-  csSeq: number;
+  source: InquirySource;
+  csSeq: string;
   inquiryUserId: string;
   inquiryName: string;
   inquiryTitle: string;
@@ -46,8 +49,8 @@ export async function myInquiries(page = 1, size = 20): Promise<PagedResponse<In
   return unwrap<PagedResponse<Inquiry>>({ data: res.data });
 }
 
-export async function myInquiryDetail(csSeq: number): Promise<Inquiry> {
-  const res = await apiClient.get<ApiResponse<Inquiry>>(`/inquiries/${csSeq}`);
+export async function myInquiryDetail(csSeq: string): Promise<Inquiry> {
+  const res = await apiClient.get<ApiResponse<Inquiry>>(`/inquiries/${encodeURIComponent(csSeq)}`);
   return unwrap<Inquiry>({ data: res.data });
 }
 

--- a/apps/user-web/src/pages/support/InquiryDetailPage.tsx
+++ b/apps/user-web/src/pages/support/InquiryDetailPage.tsx
@@ -20,12 +20,11 @@ const STATE_LABELS: Record<string, { label: string; color: string }> = {
 export function InquiryDetailPage() {
   const { csSeq } = useParams();
   const navigate = useNavigate();
-  const seqNum = Number(csSeq);
 
   const q = useQuery({
-    queryKey: ['my-inquiry', seqNum],
-    queryFn: () => myInquiryDetail(seqNum),
-    enabled: !isNaN(seqNum),
+    queryKey: ['my-inquiry', csSeq],
+    queryFn: () => myInquiryDetail(csSeq!),
+    enabled: !!csSeq,
   });
 
   const d = q.data;

--- a/backend/src/main/java/com/academy/inquiry/InquiryApi.java
+++ b/backend/src/main/java/com/academy/inquiry/InquiryApi.java
@@ -21,6 +21,9 @@ import org.springframework.web.bind.annotation.*;
  *
  * <p>ROLE_ADMIN 보호 — SecurityConfig 가 {@code /api/**} 전역 hasRole(ADMIN) 적용.
  * academy-agent (로컬 Ollama) HTTP 로 분류·유사추천·피드백.
+ *
+ * <p>{@code csSeq} 는 v_inquiry 의 통합 PK — legacy 'CSBOARD_001' 형식 또는
+ * 신규 BIGINT 의 String. 분류·답변·재배정은 신규(source='N') 만 가능.
  */
 @RestController
 @RequestMapping("/api/inquiries")
@@ -33,7 +36,7 @@ public class InquiryApi {
         this.service = service;
     }
 
-    @Operation(summary = "문의 목록 (검색·페이징)")
+    @Operation(summary = "문의 목록 (검색·페이징, legacy + 신규 통합)")
     @GetMapping
     public ApiResponse<PagedResponse<InquiryDto>> list(InquirySearchRequest req) {
         return ApiResponse.ok(service.list(req));
@@ -41,7 +44,7 @@ public class InquiryApi {
 
     @Operation(summary = "문의 상세")
     @GetMapping("/{csSeq}")
-    public ResponseEntity<ApiResponse<InquiryDto>> detail(@PathVariable long csSeq) {
+    public ResponseEntity<ApiResponse<InquiryDto>> detail(@PathVariable String csSeq) {
         InquiryDto d = service.detail(csSeq);
         if (d == null) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND)
@@ -50,9 +53,9 @@ public class InquiryApi {
         return ResponseEntity.ok(ApiResponse.ok(d));
     }
 
-    @Operation(summary = "AI 분류 재실행 (agent 호출)")
+    @Operation(summary = "AI 분류 재실행 (agent 호출, 신규 문의 전용)")
     @PostMapping("/{csSeq}/classify")
-    public ResponseEntity<ApiResponse<InquiryDto>> classifyNow(@PathVariable long csSeq) {
+    public ResponseEntity<ApiResponse<InquiryDto>> classifyNow(@PathVariable String csSeq) {
         try {
             InquiryDto d = service.classifyNow(csSeq);
             if (d == null) {
@@ -60,41 +63,58 @@ public class InquiryApi {
                     .body(ApiResponse.fail("INQUIRY_404", "문의를 찾을 수 없습니다."));
             }
             return ResponseEntity.ok(ApiResponse.ok(d));
+        } catch (IllegalStateException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.fail("LEGACY_READONLY", e.getMessage()));
         } catch (InquiryAgentClient.AgentException e) {
             return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
                 .body(ApiResponse.fail("AGENT_UNAVAILABLE", e.getMessage()));
         }
     }
 
-    @Operation(summary = "답변 저장")
+    @Operation(summary = "답변 저장 (신규 문의 전용)")
     @PostMapping("/{csSeq}/answer")
     public ResponseEntity<ApiResponse<InquiryDto>> answer(
-        @PathVariable long csSeq,
+        @PathVariable String csSeq,
         @Valid @RequestBody AnswerRequest req,
         Authentication auth
     ) {
-        String userId = auth != null ? String.valueOf(auth.getPrincipal()) : "system";
-        InquiryDto d = service.answer(csSeq, req, userId);
-        return ResponseEntity.ok(ApiResponse.ok(d));
+        try {
+            String userId = auth != null ? String.valueOf(auth.getPrincipal()) : "system";
+            InquiryDto d = service.answer(csSeq, req, userId);
+            if (d == null) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(ApiResponse.fail("INQUIRY_404", "문의를 찾을 수 없습니다."));
+            }
+            return ResponseEntity.ok(ApiResponse.ok(d));
+        } catch (IllegalStateException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.fail("LEGACY_READONLY", e.getMessage()));
+        }
     }
 
-    @Operation(summary = "담당자·카테고리 재배정")
+    @Operation(summary = "담당자·카테고리 재배정 (신규 문의 전용)")
     @PostMapping("/{csSeq}/reassign")
     public ResponseEntity<ApiResponse<InquiryDto>> reassign(
-        @PathVariable long csSeq,
+        @PathVariable String csSeq,
         @Valid @RequestBody ReassignRequest req,
         Authentication auth
     ) {
-        String userId = auth != null ? String.valueOf(auth.getPrincipal()) : "system";
-        InquiryDto d = service.reassign(csSeq, req, userId);
-        if (d == null) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(ApiResponse.fail("INQUIRY_404", "문의를 찾을 수 없습니다."));
+        try {
+            String userId = auth != null ? String.valueOf(auth.getPrincipal()) : "system";
+            InquiryDto d = service.reassign(csSeq, req, userId);
+            if (d == null) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(ApiResponse.fail("INQUIRY_404", "문의를 찾을 수 없습니다."));
+            }
+            return ResponseEntity.ok(ApiResponse.ok(d));
+        } catch (IllegalStateException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.fail("LEGACY_READONLY", e.getMessage()));
         }
-        return ResponseEntity.ok(ApiResponse.ok(d));
     }
 
-    @Operation(summary = "월간 통계 (카테고리 트렌드·AI 정확도·미해결 top)")
+    @Operation(summary = "월간 통계 (legacy + 신규 카테고리 트렌드·AI 정확도·미해결 top)")
     @GetMapping("/stats")
     public ApiResponse<com.academy.inquiry.dto.MonthlyStatsResponse> stats(
         @RequestParam(name = "ym") String yearMonth
@@ -104,7 +124,7 @@ public class InquiryApi {
 
     @Operation(summary = "유사 문의 추천 (agent 호출)")
     @GetMapping("/{csSeq}/related")
-    public ResponseEntity<ApiResponse<InquiryAgentClient.SuggestResponse>> related(@PathVariable long csSeq) {
+    public ResponseEntity<ApiResponse<InquiryAgentClient.SuggestResponse>> related(@PathVariable String csSeq) {
         try {
             InquiryAgentClient.SuggestResponse r = service.related(csSeq);
             if (r == null) {

--- a/backend/src/main/java/com/academy/inquiry/UserInquiryApi.java
+++ b/backend/src/main/java/com/academy/inquiry/UserInquiryApi.java
@@ -19,7 +19,10 @@ import org.springframework.web.bind.annotation.*;
  * 학생(USER) 전용 1:1 문의 작성·조회. Phase D.
  *
  * <p>SecurityConfig 가 {@code /api/user/**} 을 hasRole(USER) 로 보호.
- * 본인 것만 조회 가능 (selectDetail owner check).
+ * 본인 것만 조회 가능 (myDetail owner check). legacy TB_BOARD_CS 는 본 화면에서 노출 안 함.
+ *
+ * <p>{@code inquiryId} = 신규 tb_inquiry.inquiry_id (BIGINT). 사용자 작성 도메인은
+ * legacy 와 무관하므로 long 그대로 사용.
  */
 @RestController
 @RequestMapping("/api/user/inquiries")
@@ -43,7 +46,7 @@ public class UserInquiryApi {
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(d));
     }
 
-    @Operation(summary = "내 문의 목록")
+    @Operation(summary = "내 문의 목록 (신규만, legacy 미노출)")
     @GetMapping
     public ApiResponse<PagedResponse<InquiryDto>> myList(
         @RequestParam(required = false, defaultValue = "1") int page,
@@ -54,14 +57,14 @@ public class UserInquiryApi {
         return ApiResponse.ok(service.myList(userId, page, size));
     }
 
-    @Operation(summary = "내 문의 상세")
-    @GetMapping("/{csSeq}")
+    @Operation(summary = "내 문의 상세 (신규만)")
+    @GetMapping("/{inquiryId}")
     public ResponseEntity<ApiResponse<InquiryDto>> myDetail(
-        @PathVariable long csSeq,
+        @PathVariable long inquiryId,
         Authentication auth
     ) {
         String userId = String.valueOf(auth.getPrincipal());
-        InquiryDto d = service.myDetail(userId, csSeq);
+        InquiryDto d = service.myDetail(userId, inquiryId);
         if (d == null) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND)
                 .body(ApiResponse.fail("INQUIRY_404", "문의를 찾을 수 없습니다."));

--- a/backend/src/main/java/com/academy/inquiry/dto/InquiryDto.java
+++ b/backend/src/main/java/com/academy/inquiry/dto/InquiryDto.java
@@ -6,13 +6,20 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 /**
- * 문의 목록·상세 공통 응답 record.
+ * 문의 목록·상세 공통 응답 record. v_inquiry view 와 1:1 정렬.
  *
- * <p>{@code bodyPreview} 는 목록에서만 사용 (본문 HTML 일부 텍스트만).
- * {@code body} 는 상세 조회에서만 채워짐.
+ * <p>{@code source} = 'L' (legacy TB_BOARD_CS) | 'N' (new tb_inquiry) — UI 가 답변/재배정
+ * 가능 여부 판단에 사용. legacy 는 read-only.
+ *
+ * <p>{@code csSeq} = legacy 는 'CSBOARD_001' 형식 VARCHAR, 신규는 BIGINT 의 문자열 형식.
+ * 양쪽 통일 위해 String 으로 노출. 신규 단독 API (사용자 본인 작성/조회) 는 long
+ * inquiry_id 직접 사용 가능.
+ *
+ * <p>{@code bodyPreview} 는 목록에서만 사용. {@code body} 는 상세 조회에서만 채워짐.
  */
 public record InquiryDto(
-    long csSeq,
+    String source,
+    String csSeq,
     String inquiryUserId,
     String inquiryName,
     String inquiryTitle,

--- a/backend/src/main/java/com/academy/inquiry/service/InquiryService.java
+++ b/backend/src/main/java/com/academy/inquiry/service/InquiryService.java
@@ -20,15 +20,17 @@ import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.HashMap;
 
 @Service
 public class InquiryService implements Serializable {
 
     private static final long serialVersionUID = 1L;
     private static final Logger log = LoggerFactory.getLogger(InquiryService.class);
+
+    private static final String SOURCE_NEW = "N";
 
     private final InquiryMapper mapper;
     private final InquiryAgentClient agent;
@@ -46,52 +48,62 @@ public class InquiryService implements Serializable {
     }
 
     @Transactional(readOnly = true)
-    public InquiryDto detail(long csSeq) {
+    public InquiryDto detail(String csSeq) {
         return mapper.selectDetail(csSeq);
     }
 
-    /** agent 호출 → 분류 결과 저장. 실패시 예외 전파. */
+    /**
+     * agent 호출 → 분류 결과 저장. legacy 항목은 read-only 라 NotSupported 반환.
+     */
     @Transactional
-    public InquiryDto classifyNow(long csSeq) throws InquiryAgentClient.AgentException {
+    public InquiryDto classifyNow(String csSeq) throws InquiryAgentClient.AgentException {
         InquiryDto current = mapper.selectDetail(csSeq);
         if (current == null) return null;
+
+        long inquiryId = requireNewInquiryId(current);
 
         InquiryAgentClient.ClassifyResponse r = agent.classify(current.inquiryTitle(), current.body());
 
         LocalDateTime now = LocalDateTime.now();
-        mapper.updateClassification(csSeq, r.category(), r.confidence(), r.model(), now);
-        mapper.insertAnalysisLog(csSeq, r.model(), "v1", r.category(), r.confidence(),
+        mapper.updateClassification(inquiryId, r.category(), r.confidence(), r.model(), now);
+        mapper.insertAnalysisLog(inquiryId, r.model(), "v1", r.category(), r.confidence(),
             r.latency_ms(), truncate(r.reasoning(), 2000));
 
         return mapper.selectDetail(csSeq);
     }
 
     @Transactional
-    public InquiryDto answer(long csSeq, AnswerRequest req, String answeredBy) {
+    public InquiryDto answer(String csSeq, AnswerRequest req, String answeredBy) {
+        InquiryDto current = mapper.selectDetail(csSeq);
+        if (current == null) return null;
+
+        long inquiryId = requireNewInquiryId(current);
+
         String state = (req.resolutionState() == null || req.resolutionState().isBlank())
             ? "ANSWERED" : req.resolutionState();
-        mapper.updateAnswer(csSeq, req.answerBody(), answeredBy, state, LocalDateTime.now());
+        mapper.updateAnswer(inquiryId, req.answerBody(), answeredBy, state, LocalDateTime.now());
         return mapper.selectDetail(csSeq);
     }
 
     @Transactional
-    public InquiryDto reassign(long csSeq, ReassignRequest req, String changedBy) {
+    public InquiryDto reassign(String csSeq, ReassignRequest req, String changedBy) {
         InquiryDto current = mapper.selectDetail(csSeq);
         if (current == null) return null;
+
+        long inquiryId = requireNewInquiryId(current);
 
         String fromCategory = current.actualCategory() != null
             ? current.actualCategory() : current.predictedCategory();
         String fromUser = current.assignedTo();
 
-        mapper.updateReassign(csSeq, req.toCategory(), req.toUser());
+        mapper.updateReassign(inquiryId, req.toCategory(), req.toUser());
         mapper.insertRoutingLog(
-            csSeq, fromCategory, req.toCategory(), fromUser, req.toUser(),
+            inquiryId, fromCategory, req.toCategory(), fromUser, req.toUser(),
             req.reason(), changedBy, req.isAiError() ? "Y" : "N"
         );
 
-        // agent 에도 피드백 (best-effort, 실패해도 진행)
         try {
-            agent.recordFeedback(csSeq, fromCategory, req.toCategory(),
+            agent.recordFeedback(inquiryId, fromCategory, req.toCategory(),
                 req.toUser(), changedBy, req.reason(), req.isAiError());
         } catch (Exception e) {
             log.warn("agent 피드백 실패 (무시): {}", e.getMessage());
@@ -100,7 +112,7 @@ public class InquiryService implements Serializable {
         return mapper.selectDetail(csSeq);
     }
 
-    public InquiryAgentClient.SuggestResponse related(long csSeq) throws InquiryAgentClient.AgentException {
+    public InquiryAgentClient.SuggestResponse related(String csSeq) throws InquiryAgentClient.AgentException {
         InquiryDto d = mapper.selectDetail(csSeq);
         if (d == null) return null;
         return agent.suggestRelated(d.body(), 3);
@@ -113,38 +125,32 @@ public class InquiryService implements Serializable {
     /** 사용자 신규 문의 등록 후 async 분류 트리거. */
     @Transactional
     public InquiryDto createByUser(String userId, String userName, InquiryCreateRequest req) {
-        long csSeq = 0;
-        // MyBatis useGeneratedKeys — 삽입 후 키 채워짐
-        var params = new HashMap<String, Object>();
-        params.put("userId", userId);
-        params.put("name", req.inquiryName() != null && !req.inquiryName().isBlank()
-            ? req.inquiryName() : userName);
-        params.put("title", req.title());
-        params.put("body", req.body());
+        String name = req.inquiryName() != null && !req.inquiryName().isBlank()
+            ? req.inquiryName() : userName;
 
-        // 직접 mapper 메서드 호출 — return type 이 insert id
-        mapper.insertInquiry(userId,
-            req.inquiryName() != null && !req.inquiryName().isBlank()
-                ? req.inquiryName() : userName,
-            req.title(), req.body());
-        // Mapper 의 useGeneratedKeys=true 가 첫 번째 Long 반환을 채움. MyBatis 는 이를
-        // selectKey 없이 안전하게 리턴하려면 trick 필요. 간단히 재조회로 대체:
+        mapper.insertInquiry(userId, name, req.title(), req.body());
+
         InquiryDto created = mapper.selectMyList(userId, 1, 0).stream()
             .findFirst().orElse(null);
 
         if (created != null) {
-            classifyAsync(created.csSeq());
+            try {
+                long inquiryId = Long.parseLong(created.csSeq());
+                classifyAsync(inquiryId);
+            } catch (NumberFormatException e) {
+                log.warn("createByUser 후 csSeq 파싱 실패: {}", created.csSeq());
+            }
         }
         return created;
     }
 
     /** 비동기 분류 — 사용자 응답 블로킹 방지. 실패 시 로그만. */
     @Async
-    public void classifyAsync(long csSeq) {
+    public void classifyAsync(long inquiryId) {
         try {
-            classifyNow(csSeq);
+            classifyNow(String.valueOf(inquiryId));
         } catch (Exception e) {
-            log.warn("async classify 실패 cs_seq={}: {}", csSeq, e.getMessage());
+            log.warn("async classify 실패 inquiry_id={}: {}", inquiryId, e.getMessage());
         }
     }
 
@@ -158,11 +164,13 @@ public class InquiryService implements Serializable {
         return PagedResponse.of(items, p, s, total);
     }
 
-    /** 본인 문의 상세. 소유자 아니면 null. */
+    /** 본인 신규 문의 상세. 소유자 아니면 null. */
     @Transactional(readOnly = true)
-    public InquiryDto myDetail(String userId, long csSeq) {
-        InquiryDto d = mapper.selectDetail(csSeq);
-        if (d == null || !userId.equals(d.inquiryUserId())) return null;
+    public InquiryDto myDetail(String userId, long inquiryId) {
+        InquiryDto d = mapper.selectDetail(String.valueOf(inquiryId));
+        if (d == null || !SOURCE_NEW.equals(d.source()) || !userId.equals(d.inquiryUserId())) {
+            return null;
+        }
         return d;
     }
 
@@ -224,6 +232,21 @@ public class InquiryService implements Serializable {
         );
     }
 
+    /**
+     * legacy('L') 항목은 운영 액션(분류·답변·재배정) 불가. 신규('N') 항목의 csSeq 를
+     * BIGINT inquiry_id 로 파싱하여 반환.
+     */
+    private static long requireNewInquiryId(InquiryDto d) {
+        if (!SOURCE_NEW.equals(d.source())) {
+            throw new IllegalStateException("legacy 문의는 운영 액션 적용 불가: csSeq=" + d.csSeq());
+        }
+        try {
+            return Long.parseLong(d.csSeq());
+        } catch (NumberFormatException e) {
+            throw new IllegalStateException("신규 문의 csSeq 파싱 실패: " + d.csSeq(), e);
+        }
+    }
+
     private static long toLong(Object o) {
         if (o == null) return 0;
         if (o instanceof Number n) return n.longValue();
@@ -241,8 +264,4 @@ public class InquiryService implements Serializable {
         if (s == null) return null;
         return s.length() > max ? s.substring(0, max) : s;
     }
-
-    // 시그니처 미사용 — Jackson 직렬화용 더미 필드 아님
-    @SuppressWarnings("unused")
-    private static BigDecimal _unused;
 }

--- a/backend/src/main/java/com/academy/mapper/InquiryMapper.java
+++ b/backend/src/main/java/com/academy/mapper/InquiryMapper.java
@@ -9,17 +9,35 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
+/**
+ * 1:1 문의 매퍼. v_inquiry (legacy + 신규 통합) 조회와 tb_inquiry 직접 UPDATE 분리.
+ *
+ * <ul>
+ *   <li>운영자 list/detail/통계/추천 → v_inquiry (csSeq 는 String, source 포함)</li>
+ *   <li>분류/답변/재배정 UPDATE → tb_inquiry 직접 (inquiryId BIGINT) — legacy 는 read-only</li>
+ *   <li>사용자 신규 작성·본인 목록 → tb_inquiry 직접</li>
+ * </ul>
+ */
 @Mapper
 public interface InquiryMapper {
+
+    // ==============================================================
+    // 운영자 콘솔 조회 (v_inquiry — legacy + 신규 통합)
+    // ==============================================================
 
     List<InquiryDto> selectList(@Param("req") InquirySearchRequest req);
 
     long selectCount(@Param("req") InquirySearchRequest req);
 
-    InquiryDto selectDetail(@Param("csSeq") long csSeq);
+    /** csSeq = view 의 통합 PK (legacy 'CSBOARD_001' or 신규 '12345'). */
+    InquiryDto selectDetail(@Param("csSeq") String csSeq);
+
+    // ==============================================================
+    // 운영자 액션 — tb_inquiry 직접 (legacy 적용 불가)
+    // ==============================================================
 
     int updateClassification(
-        @Param("csSeq") long csSeq,
+        @Param("inquiryId") long inquiryId,
         @Param("category") String category,
         @Param("confidence") BigDecimal confidence,
         @Param("model") String model,
@@ -27,7 +45,7 @@ public interface InquiryMapper {
     );
 
     int updateAnswer(
-        @Param("csSeq") long csSeq,
+        @Param("inquiryId") long inquiryId,
         @Param("body") String answerBody,
         @Param("by") String answeredBy,
         @Param("state") String resolutionState,
@@ -35,13 +53,13 @@ public interface InquiryMapper {
     );
 
     int updateReassign(
-        @Param("csSeq") long csSeq,
+        @Param("inquiryId") long inquiryId,
         @Param("toCategory") String toCategory,
         @Param("toUser") String toUser
     );
 
     int insertRoutingLog(
-        @Param("csSeq") long csSeq,
+        @Param("inquiryId") long inquiryId,
         @Param("fromCategory") String fromCategory,
         @Param("toCategory") String toCategory,
         @Param("fromUser") String fromUser,
@@ -52,7 +70,7 @@ public interface InquiryMapper {
     );
 
     int insertAnalysisLog(
-        @Param("csSeq") long csSeq,
+        @Param("inquiryId") long inquiryId,
         @Param("modelName") String modelName,
         @Param("promptTemplate") String promptTemplate,
         @Param("parsedCategory") String parsedCategory,
@@ -60,6 +78,10 @@ public interface InquiryMapper {
         @Param("latencyMs") Integer latencyMs,
         @Param("rawOutput") String rawOutput
     );
+
+    // ==============================================================
+    // 사용자 신규 작성·본인 목록 — tb_inquiry 직접
+    // ==============================================================
 
     /** 사용자 문의 신규 등록. int = affected rows. Service 에서 selectMyList 로 최신 행 재조회. */
     int insertInquiry(
@@ -69,7 +91,7 @@ public interface InquiryMapper {
         @Param("body") String body
     );
 
-    /** 본인이 등록한 문의 목록 (inquiry_user_id = userId). */
+    /** 본인이 등록한 신규 문의 목록 (legacy 미포함). */
     List<InquiryDto> selectMyList(
         @Param("userId") String userId,
         @Param("limit") int limit,
@@ -78,12 +100,16 @@ public interface InquiryMapper {
 
     long selectMyCount(@Param("userId") String userId);
 
-    /** 특정 YYYY-MM 의 카테고리별 집계. COALESCE(actual, predicted). */
+    // ==============================================================
+    // 통계·추천 — v_inquiry
+    // ==============================================================
+
+    /** 특정 YYYY-MM 의 카테고리별 집계. COALESCE(actual, predicted). legacy + 신규 통합. */
     List<java.util.Map<String, Object>> selectMonthlyStats(@Param("ym") String ym);
 
-    /** AI 오분류 건수 / 전체 재배정 건수 — 정확도 지표. */
+    /** AI 오분류 건수 / 전체 재배정 건수 — 정확도 지표 (신규 tb_inquiry_routing_log 만). */
     java.util.Map<String, Object> selectRoutingStats(@Param("ym") String ym);
 
-    /** 미해결 문의 top-N (접수 오래된 순). */
+    /** 미해결 문의 top-N (접수 오래된 순). 사용자 유사문의 추천 풀에 활용 — legacy 포함. */
     List<InquiryDto> selectUnresolvedTop(@Param("limit") int limit);
 }

--- a/backend/src/main/resources/db/migration/V10__rename_acm_to_tb_inquiry.sql
+++ b/backend/src/main/resources/db/migration/V10__rename_acm_to_tb_inquiry.sql
@@ -1,0 +1,63 @@
+-- =====================================================================
+-- V10: acm_* → tb_* RENAME (inquiry 도메인 네이밍 일관화)
+-- =====================================================================
+-- 배경:
+--   Phase A~C 에서 acm_* prefix 로 생성한 테이블들을 tb_* 로 정렬.
+--   기존 Oracle 이관 테이블(TB_BOARD_CS 등) 과 prefix 통일.
+--   cs_seq 컬럼명도 inquiry_id 로 정렬 (신규 tb_inquiry.inquiry_id 와 매칭).
+--
+-- 변경 대상:
+--   acm_board_cs               → tb_inquiry_train      (학습 데이터셋, 마스킹 5,430건)
+--   acm_inquiry_analysis       → tb_inquiry_analysis   (AI 호출 이력)
+--   acm_inquiry_routing_log    → tb_inquiry_routing_log(재배정 로그)
+--   acm_inquiry_stats_monthly  → tb_inquiry_stats_monthly
+--   acm_inquiry_embedding      → tb_inquiry_embedding
+--
+-- 학습셋에 source 추적 컬럼 추가 — 원본이 TB_BOARD_CS 인지 신규 tb_inquiry 인지 구분.
+--
+-- 주의: inquiry.xml 이 V11 과 함께 tb_* 로 갱신되어야 함 (동시 배포).
+-- =====================================================================
+
+-- ---------------------------------------------------------------------
+-- 1. RENAME
+-- ---------------------------------------------------------------------
+RENAME TABLE acm_board_cs              TO tb_inquiry_train,
+             acm_inquiry_analysis      TO tb_inquiry_analysis,
+             acm_inquiry_routing_log   TO tb_inquiry_routing_log,
+             acm_inquiry_stats_monthly TO tb_inquiry_stats_monthly,
+             acm_inquiry_embedding     TO tb_inquiry_embedding;
+
+-- ---------------------------------------------------------------------
+-- 2. cs_seq → inquiry_id 컬럼명 정렬
+-- ---------------------------------------------------------------------
+ALTER TABLE tb_inquiry_train
+    CHANGE COLUMN cs_seq inquiry_id BIGINT NOT NULL AUTO_INCREMENT;
+
+ALTER TABLE tb_inquiry_analysis
+    CHANGE COLUMN cs_seq inquiry_id BIGINT NOT NULL;
+
+ALTER TABLE tb_inquiry_routing_log
+    CHANGE COLUMN cs_seq inquiry_id BIGINT NOT NULL;
+
+ALTER TABLE tb_inquiry_embedding
+    CHANGE COLUMN cs_seq inquiry_id BIGINT NOT NULL;
+
+-- ---------------------------------------------------------------------
+-- 3. tb_inquiry_train 에 source 추적 컬럼 추가
+--    legacy TB_BOARD_CS 이관분 / 신규 tb_inquiry 마스킹분 구분용
+-- ---------------------------------------------------------------------
+ALTER TABLE tb_inquiry_train
+    ADD COLUMN source_table VARCHAR(20) NOT NULL DEFAULT 'TB_BOARD_CS'
+               COMMENT '원본 테이블 — TB_BOARD_CS | tb_inquiry' AFTER inquiry_id,
+    ADD COLUMN source_id    VARCHAR(50) NULL
+               COMMENT '원본 PK (TB_BOARD_CS.BOARD_SEQ 또는 tb_inquiry.inquiry_id)' AFTER source_table;
+
+-- 기존 legacy_* 컬럼 값을 source_id 로 일원화
+UPDATE tb_inquiry_train
+   SET source_id = legacy_board_seq
+ WHERE source_id IS NULL
+   AND legacy_board_seq IS NOT NULL;
+
+-- 인덱스 보강 (source_table, source_id) 로 역추적·중복 확인 쉽게
+ALTER TABLE tb_inquiry_train
+    ADD KEY idx_source (source_table, source_id);

--- a/backend/src/main/resources/db/migration/V11__create_tb_inquiry.sql
+++ b/backend/src/main/resources/db/migration/V11__create_tb_inquiry.sql
@@ -1,0 +1,88 @@
+-- =====================================================================
+-- V11: tb_inquiry / tb_inquiry_file — 신규 운영 테이블
+-- =====================================================================
+-- 배경:
+--   legacy TB_BOARD_CS 는 read-only 아카이브로 보존 (Oracle CLOB 본문, 보드타입+시퀀스 PK).
+--   신규 1:1 문의 인입은 모두 tb_inquiry 로. AI 분류 표준 컬럼 일체 포함.
+--
+--   첨부파일은 별도 테이블 tb_inquiry_file 로 분리 — DB 본문 BLOB 저장 금지.
+--
+-- 표준:
+--   PK              : BIGINT AUTO_INCREMENT
+--   본문            : MEDIUMTEXT (16MB) utf8mb4
+--   답변            : answer_body 별도 컬럼 — Phase D 미답변 판별 단순화 (IS NULL)
+--   카테고리        : 4분류 (ACADEMIC|ORDER|SYSTEM|OTHER) — predicted/actual 분리
+--   resolution_state: OPEN → ANSWERED → RESOLVED → CLOSED 4단계
+--
+-- 관련 표준 문서: docs/standards/INQUIRY_MODEL_STANDARD.md (별도 PR)
+-- =====================================================================
+
+CREATE TABLE IF NOT EXISTS tb_inquiry (
+    inquiry_id              BIGINT        NOT NULL AUTO_INCREMENT,
+
+    -- 사용자 (내부망 평문, 외부 API/화면 노출 시 별칭으로 마스킹)
+    user_id                 VARCHAR(50)   NOT NULL,
+    user_name               VARCHAR(50)   NOT NULL,
+
+    -- 본문
+    title                   VARCHAR(300)  NOT NULL,
+    body                    MEDIUMTEXT    NOT NULL,
+    inquiry_date            DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    -- AI 분류 (Phase B 이후 agent 가 채움)
+    predicted_category      VARCHAR(30)   NULL  COMMENT 'ACADEMIC|ORDER|SYSTEM|OTHER',
+    predicted_confidence    DECIMAL(5,4)  NULL  COMMENT '0.0000 ~ 1.0000',
+    classified_by_model     VARCHAR(50)   NULL  COMMENT 'qwen2.5:7b@v3 식 모델 버전',
+    classified_at           DATETIME      NULL,
+
+    -- 운영자 처리 (Phase C)
+    actual_category         VARCHAR(30)   NULL  COMMENT '운영자 확정 카테고리',
+    assigned_to             VARCHAR(50)   NULL  COMMENT '담당자 user_id',
+    reroute_count           INT           NOT NULL DEFAULT 0,
+
+    -- 답변
+    answer_body             MEDIUMTEXT    NULL,
+    answered_by             VARCHAR(50)   NULL,
+    answered_at             DATETIME      NULL,
+    resolution_state        VARCHAR(20)   NOT NULL DEFAULT 'OPEN'
+                            COMMENT 'OPEN|ANSWERED|RESOLVED|CLOSED',
+    user_satisfaction       TINYINT       NULL  COMMENT '1-5 별점',
+
+    -- 감사
+    reg_dt                  DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    upd_dt                  DATETIME      NULL ON UPDATE CURRENT_TIMESTAMP,
+    is_deleted              CHAR(1)       NOT NULL DEFAULT 'N',
+
+    PRIMARY KEY (inquiry_id),
+    KEY idx_user      (user_id, inquiry_date),
+    KEY idx_state     (resolution_state, inquiry_date),
+    KEY idx_predicted (predicted_category, classified_at),
+    KEY idx_actual    (actual_category, reg_dt),
+    KEY idx_assigned  (assigned_to, resolution_state),
+    KEY idx_inquiry_date (inquiry_date)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='1:1 문의 운영 테이블 (Phase D 이후 신규 인입 전용)';
+
+
+-- ---------------------------------------------------------------------
+-- tb_inquiry_file: 첨부파일 메타 (실 파일은 디스크/S3)
+-- ---------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS tb_inquiry_file (
+    file_seq        BIGINT        NOT NULL AUTO_INCREMENT,
+    inquiry_id      BIGINT        NOT NULL,
+
+    file_name       VARCHAR(300)  NOT NULL COMMENT '원본 파일명',
+    stored_path     VARCHAR(500)  NOT NULL COMMENT '저장 경로 (서버 디스크 또는 S3 key)',
+    mime_type       VARCHAR(100)  NULL,
+    size_bytes      BIGINT        NULL,
+
+    upload_target   VARCHAR(20)   NOT NULL DEFAULT 'QUESTION'
+                    COMMENT 'QUESTION (사용자 첨부) | ANSWER (운영자 첨부)',
+
+    reg_dt          DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    is_deleted      CHAR(1)       NOT NULL DEFAULT 'N',
+
+    PRIMARY KEY (file_seq),
+    KEY idx_inquiry (inquiry_id, upload_target)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='1:1 문의 첨부파일 메타';

--- a/backend/src/main/resources/db/migration/V12__create_tb_category_mapping.sql
+++ b/backend/src/main/resources/db/migration/V12__create_tb_category_mapping.sql
@@ -1,0 +1,29 @@
+-- =====================================================================
+-- V12: tb_category_mapping — legacy CS_DIV/CS_KIND → 표준 4분류 매핑 마스터
+-- =====================================================================
+-- 배경:
+--   legacy TB_BOARD_CS 5,430건은 (CS_DIV, CS_KIND) 2단 코드로 분류됨.
+--   신규 tb_inquiry 는 4분류 표준 (ACADEMIC|ORDER|SYSTEM|OTHER) 사용.
+--   v_inquiry view 가 LEFT JOIN 으로 legacy 분류를 표준 라벨로 환원.
+--
+--   시드 INSERT 는 운영자 합의 후 별도 마이그레이션 (V12_1) 또는
+--   scripts/seed/category_mapping_seed.sql 로 분리 — 본 V12 는 스키마만 생성.
+--
+-- 매핑 결정 사전자료:
+--   SELECT CS_DIV, CS_KIND, COUNT(*) FROM TB_BOARD_CS GROUP BY CS_DIV, CS_KIND;
+-- =====================================================================
+
+CREATE TABLE IF NOT EXISTS tb_category_mapping (
+    legacy_cs_div   VARCHAR(20)  NOT NULL  COMMENT 'TB_BOARD_CS.CS_DIV',
+    legacy_cs_kind  VARCHAR(20)  NOT NULL DEFAULT ''
+                    COMMENT 'TB_BOARD_CS.CS_KIND. 빈 문자열 = CS_DIV 만으로 매칭',
+    std_category    VARCHAR(30)  NOT NULL
+                    COMMENT '표준 4분류 — ACADEMIC|ORDER|SYSTEM|OTHER',
+    remark          VARCHAR(200) NULL,
+    reg_dt          DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    upd_dt          DATETIME     NULL ON UPDATE CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (legacy_cs_div, legacy_cs_kind),
+    KEY idx_std (std_category)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='legacy CS 분류 ↔ 신규 4분류 매핑 마스터';

--- a/backend/src/main/resources/db/migration/V13__create_v_inquiry.sql
+++ b/backend/src/main/resources/db/migration/V13__create_v_inquiry.sql
@@ -1,0 +1,93 @@
+-- =====================================================================
+-- V13: v_inquiry — legacy + 신규 통합 조회 view
+-- =====================================================================
+-- 배경:
+--   운영자 콘솔·통계·유사문의 추천이 legacy TB_BOARD_CS 5,430건과
+--   신규 tb_inquiry 인입분을 동일 스키마로 조회해야 함.
+--
+-- 설계:
+--   - inquiry_id = VARCHAR(50) 통일 (legacy BOARD_SEQ 'CSBOARD_001' 형식 + 신규 BIGINT 양쪽 수용)
+--   - source     = 'L' (Legacy TB_BOARD_CS) | 'N' (New tb_inquiry)
+--   - legacy CS_DIV/CS_KIND → tb_category_mapping LEFT JOIN 으로 표준 4분류 환원
+--   - legacy 는 read-only — UPDATE 쿼리는 v_inquiry 거치지 않고 tb_inquiry 직접 사용
+--
+-- 컬럼 구성: InquiryDto 와 1:1 정렬.
+-- =====================================================================
+
+CREATE OR REPLACE VIEW v_inquiry AS
+-- ---------------------------------------------------------------------
+-- Legacy: TB_BOARD_CS (Oracle 이관, CLOB 본문)
+-- ---------------------------------------------------------------------
+SELECT
+    'L'                                              AS source,
+    L.BOARD_SEQ                                      AS inquiry_id,
+    L.REG_ID                                         AS user_id,
+    COALESCE(L.REG_NM, L.CREATENAME)                 AS user_name,
+    L.SUBJECT                                        AS title,
+    LEFT(CONVERT(L.CONTENT USING utf8mb4), 65535)    AS body,
+    L.REG_DT                                         AS inquiry_date,
+
+    -- AI 분류 — legacy retro-classify 결과는 tb_inquiry_train 에 저장되므로
+    -- 여기서는 NULL. 운영자 콘솔에는 표준 매핑만 표시.
+    NULL                                             AS predicted_category,
+    NULL                                             AS predicted_confidence,
+    NULL                                             AS classified_by_model,
+    NULL                                             AS classified_at,
+
+    M.std_category                                   AS actual_category,
+    L.COUNSELOR_ID                                   AS assigned_to,
+    0                                                AS reroute_count,
+
+    -- legacy 는 답변이 CONTENT 에 합쳐있을 수 있어 별도 노출 불가
+    NULL                                             AS answer_body,
+    L.COUNSELOR_ID                                   AS answered_by,
+    NULL                                             AS answered_at,
+    CASE L.ACTION_YN
+        WHEN 'Y' THEN 'RESOLVED'
+        ELSE          'OPEN'
+    END                                              AS resolution_state,
+    NULL                                             AS user_satisfaction,
+
+    L.REG_DT                                         AS reg_dt,
+    NULL                                             AS upd_dt,
+    'N'                                              AS is_deleted
+FROM TB_BOARD_CS L
+LEFT JOIN tb_category_mapping M
+       ON M.legacy_cs_div  = L.CS_DIV
+      AND (M.legacy_cs_kind = COALESCE(L.CS_KIND, '') OR M.legacy_cs_kind = '')
+WHERE L.OPEN_YN <> 'D' OR L.OPEN_YN IS NULL  -- 삭제 표시가 있는 경우 대비
+
+UNION ALL
+
+-- ---------------------------------------------------------------------
+-- New: tb_inquiry (Phase D 이후 신규 인입)
+-- ---------------------------------------------------------------------
+SELECT
+    'N'                                              AS source,
+    CAST(N.inquiry_id AS CHAR(20))                   AS inquiry_id,
+    N.user_id,
+    N.user_name,
+    N.title,
+    N.body,
+    N.inquiry_date,
+
+    N.predicted_category,
+    N.predicted_confidence,
+    N.classified_by_model,
+    N.classified_at,
+
+    N.actual_category,
+    N.assigned_to,
+    N.reroute_count,
+
+    N.answer_body,
+    N.answered_by,
+    N.answered_at,
+    N.resolution_state,
+    N.user_satisfaction,
+
+    N.reg_dt,
+    N.upd_dt,
+    N.is_deleted
+FROM tb_inquiry N
+WHERE N.is_deleted = 'N';

--- a/backend/src/main/resources/mapper/inquiry.xml
+++ b/backend/src/main/resources/mapper/inquiry.xml
@@ -1,10 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <!--
-  CS 문의 운영자 콘솔용 쿼리. acm_board_cs (Phase A) 기반.
+  CS 1:1 문의 매퍼.
+
+  - 운영자 list/detail/통계/추천 → v_inquiry (legacy + 신규 통합)
+  - 분류/답변/재배정 UPDATE     → tb_inquiry 직접 (legacy 는 read-only)
+  - 사용자 신규 작성·본인 목록 → tb_inquiry 직접 (신규만)
+  - AI 호출·재배정 로그         → tb_inquiry_analysis / tb_inquiry_routing_log
 -->
 <mapper namespace="com.academy.mapper.InquiryMapper">
 
+    <!-- =============================================================
+         공통 WHERE — v_inquiry 기준
+         ============================================================= -->
     <sql id="listWhere">
         <where>
             is_deleted = 'N'
@@ -19,19 +27,23 @@
                 AND assigned_to = #{req.assignedTo}
             </if>
             <if test="req.keyword != null and req.keyword != ''">
-                AND (inquiry_title LIKE CONCAT('%', #{req.keyword}, '%')
-                     OR inquiry_body LIKE CONCAT('%', #{req.keyword}, '%'))
+                AND (title LIKE CONCAT('%', #{req.keyword}, '%')
+                     OR body  LIKE CONCAT('%', #{req.keyword}, '%'))
             </if>
         </where>
     </sql>
 
+    <!-- =============================================================
+         운영자 콘솔 조회 — v_inquiry
+         ============================================================= -->
     <select id="selectList" resultType="com.academy.inquiry.dto.InquiryDto">
         SELECT
-            cs_seq                AS csSeq,
-            inquiry_user_id       AS inquiryUserId,
-            inquiry_name          AS inquiryName,
-            inquiry_title         AS inquiryTitle,
-            LEFT(inquiry_body, 200)  AS bodyPreview,
+            source,
+            inquiry_id            AS csSeq,
+            user_id               AS inquiryUserId,
+            user_name             AS inquiryName,
+            title                 AS inquiryTitle,
+            LEFT(body, 200)       AS bodyPreview,
             NULL                  AS body,
             inquiry_date          AS inquiryDate,
             predicted_category    AS predictedCategory,
@@ -46,25 +58,26 @@
             answered_at           AS answeredAt,
             resolution_state      AS resolutionState,
             user_satisfaction     AS userSatisfaction
-        FROM acm_board_cs
+        FROM v_inquiry
         <include refid="listWhere"/>
-        ORDER BY inquiry_date DESC, cs_seq DESC
+        ORDER BY inquiry_date DESC, inquiry_id DESC
         LIMIT #{req.sizeOrDefault} OFFSET #{req.offset}
     </select>
 
     <select id="selectCount" resultType="long">
-        SELECT COUNT(*) FROM acm_board_cs
+        SELECT COUNT(*) FROM v_inquiry
         <include refid="listWhere"/>
     </select>
 
     <select id="selectDetail" resultType="com.academy.inquiry.dto.InquiryDto">
         SELECT
-            cs_seq                AS csSeq,
-            inquiry_user_id       AS inquiryUserId,
-            inquiry_name          AS inquiryName,
-            inquiry_title         AS inquiryTitle,
+            source,
+            inquiry_id            AS csSeq,
+            user_id               AS inquiryUserId,
+            user_name             AS inquiryName,
+            title                 AS inquiryTitle,
             NULL                  AS bodyPreview,
-            inquiry_body          AS body,
+            body                  AS body,
             inquiry_date          AS inquiryDate,
             predicted_category    AS predictedCategory,
             predicted_confidence  AS predictedConfidence,
@@ -78,70 +91,74 @@
             answered_at           AS answeredAt,
             resolution_state      AS resolutionState,
             user_satisfaction     AS userSatisfaction
-        FROM acm_board_cs
-        WHERE cs_seq = #{csSeq}
+        FROM v_inquiry
+        WHERE inquiry_id = #{csSeq}
           AND is_deleted = 'N'
     </select>
 
+    <!-- =============================================================
+         운영자 액션 — tb_inquiry 직접 (legacy 적용 불가)
+         ============================================================= -->
     <update id="updateClassification">
-        UPDATE acm_board_cs
+        UPDATE tb_inquiry
            SET predicted_category   = #{category},
                predicted_confidence = #{confidence},
                classified_by_model  = #{model},
                classified_at        = #{classifiedAt}
-         WHERE cs_seq = #{csSeq}
+         WHERE inquiry_id = #{inquiryId}
     </update>
 
     <update id="updateAnswer">
-        UPDATE acm_board_cs
+        UPDATE tb_inquiry
            SET answer_body      = #{body},
                answered_by      = #{by},
                answered_at      = #{answeredAt},
                resolution_state = #{state},
                upd_dt           = CURRENT_TIMESTAMP
-         WHERE cs_seq = #{csSeq}
+         WHERE inquiry_id = #{inquiryId}
     </update>
 
     <update id="updateReassign">
-        UPDATE acm_board_cs
+        UPDATE tb_inquiry
            SET actual_category = #{toCategory},
                assigned_to     = #{toUser},
                reroute_count   = reroute_count + 1,
                upd_dt          = CURRENT_TIMESTAMP
-         WHERE cs_seq = #{csSeq}
+         WHERE inquiry_id = #{inquiryId}
     </update>
 
     <insert id="insertRoutingLog">
-        INSERT INTO acm_inquiry_routing_log (
-            cs_seq, from_category, to_category, from_user, to_user,
+        INSERT INTO tb_inquiry_routing_log (
+            inquiry_id, from_category, to_category, from_user, to_user,
             reason, changed_by, is_ai_error
         ) VALUES (
-            #{csSeq}, #{fromCategory}, #{toCategory}, #{fromUser}, #{toUser},
+            #{inquiryId}, #{fromCategory}, #{toCategory}, #{fromUser}, #{toUser},
             #{reason}, #{changedBy}, #{isAiError}
         )
     </insert>
 
     <insert id="insertAnalysisLog">
-        INSERT INTO acm_inquiry_analysis (
-            cs_seq, model_name, prompt_template, parsed_category,
+        INSERT INTO tb_inquiry_analysis (
+            inquiry_id, model_name, prompt_template, parsed_category,
             confidence, latency_ms, raw_output
         ) VALUES (
-            #{csSeq}, #{modelName}, #{promptTemplate}, #{parsedCategory},
+            #{inquiryId}, #{modelName}, #{promptTemplate}, #{parsedCategory},
             #{confidence}, #{latencyMs}, #{rawOutput}
         )
     </insert>
 
-    <!-- ============================================================== -->
-    <!-- Phase D 추가 — 사용자 문의 작성·본인 목록·통계                   -->
-    <!-- ============================================================== -->
-
-    <!-- useGeneratedKeys + keyProperty 는 @Param 기반 mapper 에 쓰면 Jdbc3KeyGenerator 가
-         parameter 를 Map/POJO 로 가정하고 BeanWrapper NPE. Service 에서 selectMyList(limit=1)
-         로 재조회하므로 생성 키 반환 불필요. -->
+    <!-- =============================================================
+         사용자 신규 작성·본인 목록 — tb_inquiry 직접
+         ============================================================= -->
+    <!--
+       useGeneratedKeys + keyProperty 는 @Param 기반 mapper 에 쓰면 Jdbc3KeyGenerator 가
+       parameter 를 Map/POJO 로 가정하고 BeanWrapper NPE. Service 에서 selectMyList(limit=1)
+       로 재조회하므로 생성 키 반환 불필요.
+    -->
     <insert id="insertInquiry">
-        INSERT INTO acm_board_cs (
-            inquiry_user_id, inquiry_name,
-            inquiry_title, inquiry_body, inquiry_date,
+        INSERT INTO tb_inquiry (
+            user_id, user_name,
+            title, body, inquiry_date,
             resolution_state, reg_dt
         ) VALUES (
             #{userId}, #{name},
@@ -152,45 +169,49 @@
 
     <select id="selectMyList" resultType="com.academy.inquiry.dto.InquiryDto">
         SELECT
-            cs_seq                AS csSeq,
-            inquiry_user_id       AS inquiryUserId,
-            inquiry_name          AS inquiryName,
-            inquiry_title         AS inquiryTitle,
-            LEFT(inquiry_body, 200)  AS bodyPreview,
-            NULL                  AS body,
-            inquiry_date          AS inquiryDate,
-            predicted_category    AS predictedCategory,
-            predicted_confidence  AS predictedConfidence,
-            classified_by_model   AS classifiedByModel,
-            classified_at         AS classifiedAt,
-            actual_category       AS actualCategory,
-            assigned_to           AS assignedTo,
-            reroute_count         AS rerouteCount,
-            NULL                  AS answerBody,
-            answered_by           AS answeredBy,
-            answered_at           AS answeredAt,
-            resolution_state      AS resolutionState,
-            user_satisfaction     AS userSatisfaction
-        FROM acm_board_cs
-        WHERE inquiry_user_id = #{userId}
+            'N'                         AS source,
+            CAST(inquiry_id AS CHAR(20)) AS csSeq,
+            user_id                     AS inquiryUserId,
+            user_name                   AS inquiryName,
+            title                       AS inquiryTitle,
+            LEFT(body, 200)             AS bodyPreview,
+            NULL                        AS body,
+            inquiry_date                AS inquiryDate,
+            predicted_category          AS predictedCategory,
+            predicted_confidence        AS predictedConfidence,
+            classified_by_model         AS classifiedByModel,
+            classified_at               AS classifiedAt,
+            actual_category             AS actualCategory,
+            assigned_to                 AS assignedTo,
+            reroute_count               AS rerouteCount,
+            NULL                        AS answerBody,
+            answered_by                 AS answeredBy,
+            answered_at                 AS answeredAt,
+            resolution_state            AS resolutionState,
+            user_satisfaction           AS userSatisfaction
+        FROM tb_inquiry
+        WHERE user_id = #{userId}
           AND is_deleted = 'N'
-        ORDER BY inquiry_date DESC, cs_seq DESC
+        ORDER BY inquiry_date DESC, inquiry_id DESC
         LIMIT #{limit} OFFSET #{offset}
     </select>
 
     <select id="selectMyCount" resultType="long">
-        SELECT COUNT(*) FROM acm_board_cs
-        WHERE inquiry_user_id = #{userId}
+        SELECT COUNT(*) FROM tb_inquiry
+        WHERE user_id = #{userId}
           AND is_deleted = 'N'
     </select>
 
+    <!-- =============================================================
+         통계·추천 — v_inquiry (legacy + 신규 통합)
+         ============================================================= -->
     <select id="selectMonthlyStats" resultType="java.util.Map">
         SELECT
             COALESCE(actual_category, predicted_category, 'OTHER') AS category,
             COUNT(*) AS totalCount,
             SUM(CASE WHEN resolution_state IN ('ANSWERED','RESOLVED') THEN 1 ELSE 0 END) AS resolvedCount,
             AVG(user_satisfaction) AS avgSatisfaction
-        FROM acm_board_cs
+        FROM v_inquiry
         WHERE DATE_FORMAT(inquiry_date, '%Y-%m') = #{ym}
           AND is_deleted = 'N'
         GROUP BY category
@@ -200,17 +221,18 @@
         SELECT
             COUNT(*) AS totalLog,
             SUM(CASE WHEN is_ai_error = 'Y' THEN 1 ELSE 0 END) AS aiErrorCount
-        FROM acm_inquiry_routing_log
+        FROM tb_inquiry_routing_log
         WHERE DATE_FORMAT(changed_at, '%Y-%m') = #{ym}
     </select>
 
     <select id="selectUnresolvedTop" resultType="com.academy.inquiry.dto.InquiryDto">
         SELECT
-            cs_seq                AS csSeq,
-            inquiry_user_id       AS inquiryUserId,
-            inquiry_name          AS inquiryName,
-            inquiry_title         AS inquiryTitle,
-            LEFT(inquiry_body, 100)  AS bodyPreview,
+            source,
+            inquiry_id            AS csSeq,
+            user_id               AS inquiryUserId,
+            user_name             AS inquiryName,
+            title                 AS inquiryTitle,
+            LEFT(body, 100)       AS bodyPreview,
             NULL                  AS body,
             inquiry_date          AS inquiryDate,
             predicted_category    AS predictedCategory,
@@ -225,7 +247,7 @@
             answered_at           AS answeredAt,
             resolution_state      AS resolutionState,
             user_satisfaction     AS userSatisfaction
-        FROM acm_board_cs
+        FROM v_inquiry
         WHERE is_deleted = 'N'
           AND resolution_state = 'OPEN'
         ORDER BY inquiry_date ASC


### PR DESCRIPTION
## Summary

- legacy `TB_BOARD_CS` (Oracle 이관, read-only) + 신규 `tb_inquiry` 운영 테이블 + `v_inquiry` 통합 view 3계층 분리
- `acm_*` 5개 테이블 → `tb_inquiry_*` 로 RENAME (네이밍 일관화, `cs_seq` → `inquiry_id`)
- 운영자 콘솔은 legacy + 신규 통합 조회, 분류·답변·재배정 액션은 신규(`source='N'`)만 가능 — UI 에 Legacy/New 배지로 명시

## 변경 내역

### Migration (V10~V13)
- **V10**: `acm_board_cs`/`acm_inquiry_*` 5개 → `tb_inquiry_train`/`tb_inquiry_*` RENAME, `cs_seq` → `inquiry_id`, 학습셋에 `source_table`/`source_id` 추적 컬럼 추가
- **V11**: `tb_inquiry` (BIGINT PK, MEDIUMTEXT utf8mb4, body/answer_body 분리), `tb_inquiry_file` (첨부 분리)
- **V12**: `tb_category_mapping` — legacy CS_DIV/CS_KIND ↔ 4분류 매핑 마스터 (시드는 후속 V12_1)
- **V13**: `v_inquiry` view — `TB_BOARD_CS` UNION `tb_inquiry`, `LEFT JOIN tb_category_mapping` 으로 통계 호환

### Backend
- `InquiryDto`: `source` 추가, `csSeq` long → String (legacy 'CSBOARD_001' / 신규 BIGINT 통합)
- `InquiryService`: `requireNewInquiryId()` helper 로 legacy 운영 액션 차단
- `InquiryApi`: `csSeq` String, `LEGACY_READONLY` 응답 코드 추가
- `UserInquiryApi`: 신규만 다루므로 `inquiryId` long 유지
- `inquiry.xml` 14쿼리 redirect (운영자 = `v_inquiry`, 액션 = `tb_inquiry` 직접)

### Frontend
- admin-web: list # 컬럼에 Legacy/New 배지, legacy 행은 분류·답변·재배정 폼 숨김 + 안내 Alert
- user-web: `csSeq` string PK 수용

## 운영 정책 반영

- `TB_BOARD_CS` 는 read-only 아카이브 — ALTER/INSERT 금지 (Oracle CLOB 본문, 보드타입+시퀀스 PK 보존)
- 신규 인입은 모두 `tb_inquiry` 로
- 학습 데이터셋 `tb_inquiry_train` 에 legacy 마스킹 5,430건 + 신규 마스킹분 단일 통합

## Test plan
- [ ] backend `mvn test` (CI ci-main.yml 자동)
- [ ] frontend typecheck/build (CI ci-main.yml 자동)
- [ ] V10~V13 Flyway 마이그레이션 prod DB 적용 확인 (deploy 후)
- [ ] 운영자 콘솔 list 에 Legacy/New 배지 표시 확인
- [ ] legacy 행 클릭 시 답변·재분류 버튼 비활성·안내 표시
- [ ] 신규 행 답변/재배정 정상 동작
- [ ] 사용자 본인 목록에 legacy 미노출 확인

## 후속 PR 후보
1. V12_1 카테고리 매핑 시드 (운영자 합의 후)
2. legacy retro-classify batch — 5,430건을 신규 모델로 분류해 `tb_inquiry_train.predicted_category` 채움
3. academy-agent 페이로드 정렬 — `RelatedItem.cs_seq` (BIGINT) ↔ `v_inquiry.inquiry_id` (String)
4. `v_inquiry` charset 검증 — 운영 `TB_BOARD_CS.CONTENT` character set 샘플 5건
5. 모델 표준 문서 — `docs/standards/INQUIRY_MODEL_STANDARD.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)