### PR TITLE
feat(landing): academy.unmong.com 시작페이지 라우팅

### DIFF
--- a/infra/nginx/academy.conf
+++ b/infra/nginx/academy.conf
@@ -113,6 +113,26 @@ server {
         include /etc/nginx/conf.d/proxy-params.conf;
     }
 
+    # 시작페이지: 자체 도메인 / 진입 시 unmong-main static landing 으로 분기
+    # 표준: Claude-Opus-bluevlad/standards/documentation/SERVICE_LANDING_GUIDE.md
+    # academy frontend(:4002) 컨테이너가 ⏸️ 인 경우에도 /, /intro.html 은 정상 노출.
+    location = / {
+        proxy_pass http://host.docker.internal:8888/services/academy.html;
+        include /etc/nginx/conf.d/proxy-params.conf;
+    }
+    location = /intro.html {
+        proxy_pass http://host.docker.internal:8888/services/academy.html;
+        include /etc/nginx/conf.d/proxy-params.conf;
+    }
+    location = /favicon.ico {
+        proxy_pass http://host.docker.internal:8888/favicon.ico;
+        include /etc/nginx/conf.d/proxy-params.conf;
+    }
+    location /css/service-landing.css {
+        proxy_pass http://host.docker.internal:8888/css/service-landing.css;
+        include /etc/nginx/conf.d/proxy-params.conf;
+    }
+
     # User Frontend (default)
     location / {
         proxy_pass http://host.docker.internal:4002;

--- a/infra/nginx/academy.conf
+++ b/infra/nginx/academy.conf
@@ -113,26 +113,12 @@ server {
         include /etc/nginx/conf.d/proxy-params.conf;
     }
 
-    # 시작페이지: 자체 도메인 / 진입 시 unmong-main static landing 으로 분기
-    # 표준: Claude-Opus-bluevlad/standards/documentation/SERVICE_LANDING_GUIDE.md
-    # academy frontend(:4002) 컨테이너가 ⏸️ 인 경우에도 /, /intro.html 은 정상 노출.
-    location = / {
-        proxy_pass http://host.docker.internal:8888/services/academy.html;
-        include /etc/nginx/conf.d/proxy-params.conf;
-    }
-    location = /intro.html {
-        proxy_pass http://host.docker.internal:8888/services/academy.html;
-        include /etc/nginx/conf.d/proxy-params.conf;
-    }
-    location = /favicon.ico {
-        proxy_pass http://host.docker.internal:8888/favicon.ico;
-        include /etc/nginx/conf.d/proxy-params.conf;
-    }
-    location /css/service-landing.css {
-        proxy_pass http://host.docker.internal:8888/css/service-landing.css;
-        include /etc/nginx/conf.d/proxy-params.conf;
-    }
-
+    # 시작페이지 / 정적 자원은 user-web(:4002) 자체 호스팅으로 처리:
+    #   - / → React DashboardPage (apps/user-web/src/App.tsx 의 public route)
+    #   - /intro.html → apps/user-web/public/intro.html (정적 5섹션 랜딩)
+    #   - /css/service-landing.css → apps/user-web/public/css/service-landing.css
+    # 표준: Claude-Opus-bluevlad/standards/documentation/SERVICE_LANDING_GUIDE.md §1
+    # ("unmong-main 포털에 의존하지 않고 각 서비스가 자체 도메인 / 에서 직접 제공")
     # User Frontend (default)
     location / {
         proxy_pass http://host.docker.internal:4002;


### PR DESCRIPTION
## Summary
- \`academy.unmong.com\` 자체 도메인 \`/\` 진입 시 unmong-main static landing (\`/services/academy.html\`) 으로 reverse-proxy 분기 추가
- frontend(:4002) 컨테이너가 ⏸️ 인 상태에서도 \`/\` 와 \`/intro.html\` 시작페이지 정상 노출
- 컨테이너 기동 시 다른 라우트(API, /admin/, SPA assets)는 기존대로 :9001/:4001/:4002 로 proxy

## 변경 파일
- \`infra/nginx/academy.conf\` — \`location = /\`, \`/intro.html\`, \`/favicon.ico\`, \`/css/service-landing.css\` exact match 분기 삽입 (\`location /\` user frontend 위에)

## Test plan
- [ ] gateway 재시작 후 \`https://academy.unmong.com/\` 시작페이지 정상 노출
- [ ] \`/login\`, \`/admin/\`, \`/api/\` 등 기존 라우트 회귀 없음
- [ ] frontend 컨테이너 기동 시 user SPA 진입 경로 정상 동작

## 참고
표준: Claude-Opus-bluevlad/standards/documentation/SERVICE_LANDING_GUIDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)