### PR TITLE
chore(ops): hopenvision 통합 흡수 — academy 단독 docker 운영 중단

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,8 +1,17 @@
 name: Deploy Academy to Production
 
+# =============================================================================
+# [SUSPENDED] 자동 배포 비활성 — 2026-04-28
+# 사유: academy 가 hopenvision 통합 환경으로 흡수됨. 운영 배포는 hopenvision 쪽에서 처리.
+#       prod 브랜치에 push 가 들어와도 자동 docker compose up 되지 않도록 push 트리거 제거.
+# 단독 재개: 아래 push 트리거 주석을 풀고, 루트 docker-compose.yml 의 restart 정책도
+#            함께 unless-stopped 로 되돌려야 함 (현재 restart: "no" 로 설정됨).
+# 수동 실행 한정으로 workflow_dispatch 만 남겨둠 — Actions UI 에서 명시적으로만 실행 가능.
+# =============================================================================
 on:
-  push:
-    branches: [ "prod" ]
+  workflow_dispatch:
+  # push:
+  #   branches: [ "prod" ]
 
 env:
   # Claude-Opus-bluevlad ENVIRONMENT_STANDARD §8.3 — Single Source of Truth

--- a/README.md
+++ b/README.md
@@ -1,7 +1,41 @@
 # academy-integrated
 
-> **Academy 통합 학원 운영 시스템** — 단일 Docker compose 로 관리자·수강생 풀 스택 배포.
-> Sprint 0~6 backend 완료, ADR-006/007 기반 FE 재작성 중 (feat/fe-ant-design-rewrite).
+> **Academy 통합 학원 운영 시스템** — Sprint 0~6 backend 완료, ADR-006/007 기반 FE 재작성 중 (feat/fe-ant-design-rewrite).
+
+---
+
+## ⚠️ [SUSPENDED] 단독 docker 운영 중단 — 2026-04-28
+
+이 repo 의 docker compose 운영은 **중단**되었습니다.
+academy 가 **hopenvision 통합 환경으로 흡수**되어, 운영은 hopenvision 쪽 단일 compose 에서 관리합니다.
+
+| 항목 | 상태 |
+|---|---|
+| 컨테이너 (backend·admin-web·user-web·redis·agent) | ⛔ 모두 stop + remove 완료 |
+| 이미지 | ✅ 보존 (`docker images | grep academy`) — rebuild 없이 재기동 가능 |
+| 볼륨 `academy_redis_data` | ✅ 보존 — 삭제 금지 |
+| 자동 재시작 정책 | 🚫 모든 compose 의 `restart: "no"` — **서버/도커 재부팅 시 자동 기동되지 않음** |
+| GitHub Actions `deploy-prod.yml` | 🚫 push 트리거 주석 처리, `workflow_dispatch` 수동 실행만 가능 |
+| 소스 / `docker-compose.yml` / `Dockerfile` | ✅ 보존 — 단독 재개 가능성을 위해 그대로 둠 |
+
+### 단독 재개가 필요한 경우 (긴급 시나리오 한정)
+
+> ⚠️ 정상 운영은 hopenvision 으로 가세요. 아래는 hopenvision 다운 등 비상 시나리오 전용.
+
+1. hopenvision 에서 academy 가 분리된 상태인지 확인 — 포트 9001 / 4001 / 4002 / 6379 / 9011 충돌 주의
+2. 환경변수 SSoT 링크 확인: `/Users/rainend/GIT/Claude-Opus-bluevlad/infrastructure/docker/.env.production`
+3. 기동:
+   ```bash
+   cd /Users/rainend/GIT/academy
+   docker compose --profile all up -d
+   ```
+4. 운영 종료 즉시:
+   ```bash
+   docker compose --profile all down
+   ```
+5. 다시 영구 운영하려면 각 compose 파일의 `restart: "no"` → `unless-stopped` 로 되돌리고, `deploy-prod.yml` 의 `push:` 트리거 주석을 풀어야 함.
+
+---
 
 ## 아키텍처
 
@@ -53,11 +87,9 @@ npm install                 # workspaces 설치 (루트에서)
 npm run dev:admin            # http://localhost:4001
 npm run dev:user             # http://localhost:3003
 
-# 3) 통합 (Docker compose)
-docker compose --profile all up -d
-curl http://localhost:9000/api/shared/health
-open http://localhost:4001
-open http://localhost:3003
+# 3) 통합 (Docker compose)  — ⚠️ SUSPENDED, hopenvision 통합으로 운영 이관됨
+#    상단 [SUSPENDED] 섹션 참조. 비상 시나리오 외에는 사용 금지.
+# docker compose --profile all up -d
 ```
 
 ## URL 경로 경계 (Sprint 1-5 · ADR-002)

--- a/backend/docker-compose.local.yml
+++ b/backend/docker-compose.local.yml
@@ -1,3 +1,9 @@
+# =============================================================================
+# [SUSPENDED] backend Windows 로컬 compose — 2026-04-28
+# 사유: academy 가 hopenvision 통합 환경으로 흡수됨. 운영은 hopenvision 단일 compose.
+# 자동 재시작: restart: "no" — 서버/도커 재부팅에도 자동 기동 안 됨.
+# 단독 재개: cd backend && docker compose -f docker-compose.local.yml up -d (긴급 시나리오 한정)
+# =============================================================================
 version: '3.8'
 
 services:
@@ -16,4 +22,4 @@ services:
       - SUPER_ADMIN_EMAILS=${SUPER_ADMIN_EMAILS:-}
     extra_hosts:
       - "host.docker.internal:host-gateway"
-    restart: always
+    restart: "no"  # SUSPENDED — hopenvision 통합 후 단독 운영 중단 (2026-04-28)

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,3 +1,10 @@
+# =============================================================================
+# [SUSPENDED] backend 단독 docker compose — 2026-04-28
+# 사유: academy 가 hopenvision 통합 환경으로 흡수됨. 운영은 hopenvision 쪽 단일 compose.
+# 자동 재시작: restart: "no" — 서버/도커 재부팅에도 자동 기동 안 됨.
+# 단독 재개: cd backend && docker compose -f docker-compose.yml up -d (긴급 시나리오 한정)
+# 운영 사용 금지 — 운영은 루트 docker-compose.yml (그 파일도 SUSPENDED) 사용했었음.
+# =============================================================================
 version: '3.8'
 
 services:
@@ -18,7 +25,7 @@ services:
       - SUPER_ADMIN_EMAILS=${SUPER_ADMIN_EMAILS:-}
     extra_hosts:
       - "host.docker.internal:host-gateway"
-    restart: always
+    restart: "no"  # SUSPENDED — hopenvision 통합 후 단독 운영 중단 (2026-04-28)
   # 데이터베이스 컨테이너가 필요한 경우 주석 해제하여 사용하세요
   # db:
   #   image: mysql:8.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,29 @@
-# Academy 통합 학원 운영 시스템 — compose
+# =============================================================================
+# [SUSPENDED] Academy 단독 docker 운영 중단 — 2026-04-28
+# -----------------------------------------------------------------------------
+# 사유: academy 가 hopenvision 통합 환경으로 흡수됨. 운영은 hopenvision 쪽에서
+#       단일 compose 로 관리. 이 파일은 단독 재개 가능성을 위해 보존만 한다.
 #
-# 4 컨테이너: backend · admin-web · user-web · redis
-# DB (MariaDB) 는 호스트 네이티브 mariadbd 를 host.docker.internal 로 접근.
+# 자동 재시작 정책:
+#   - 모든 서비스 restart: "no" — Docker daemon/서버 재부팅 시에도 살아나지 않음.
+#   - `docker compose ... up` 을 명시적으로 호출하지 않는 한 절대 기동되지 않음.
 #
-# 환경변수 (ENVIRONMENT_STANDARD §8.3 — Single Source of Truth):
-#   운영: /Users/rainend/GIT/Claude-Opus-bluevlad/infrastructure/docker/.env.production
-#   로컬 개발: academy repo 루트의 .env (gitignored)
-#   접두사 규약 §8.2: Academy 전용은 ACADEMY_*, 공통은 GOOGLE_*/SUPER_ADMIN_*/TZ
+# 단독 재개가 필요한 경우 (긴급 시나리오 한정):
+#   1) hopenvision 에서 academy 가 분리된 상태인지 확인 (포트 9001/4001/4002/6379 충돌 주의)
+#   2) cd /Users/rainend/GIT/academy
+#   3) docker compose --profile all up -d
+#   4) 운영 종료 시 즉시 docker compose --profile all down
 #
-# 포트 (§5.2): Admin 4001, User 4002, Backend 9001 (monorepo 단일)
+# 보존 자산:
+#   - 이미지: academy-academy-{backend,admin-web,user-web,agent} (rebuild 없이 재기동 가능)
+#   - 볼륨:  academy_redis_data (Redis 영속 데이터, 삭제 금지)
 #
-# 기동:  docker compose --profile all up -d
-# 로그:  docker compose logs -f --tail=100 academy-backend
+# 원본 운영 메모 (참고):
+#   4 컨테이너: backend · admin-web · user-web · redis (+ agent)
+#   DB(MariaDB) 호스트 네이티브 → host.docker.internal
+#   환경변수 SSoT: /Users/rainend/GIT/Claude-Opus-bluevlad/infrastructure/docker/.env.production
+#   포트(ENVIRONMENT_STANDARD §5.2): Admin 4001 · User 4002 · Backend 9001
+# =============================================================================
 services:
 
   academy-backend:
@@ -45,7 +57,7 @@ services:
       - academy-redis
     extra_hosts:
       - "host.docker.internal:host-gateway"
-    restart: unless-stopped
+    restart: "no"  # SUSPENDED — hopenvision 통합 후 단독 운영 중단 (2026-04-28)
     profiles:
       - all
       - backend
@@ -63,7 +75,7 @@ services:
       - "${ACADEMY_ADMIN_WEB_PORT:-4001}:80"
     depends_on:
       - academy-backend
-    restart: unless-stopped
+    restart: "no"  # SUSPENDED — hopenvision 통합 후 단독 운영 중단 (2026-04-28)
     profiles:
       - all
       - frontend
@@ -79,7 +91,7 @@ services:
       - "${ACADEMY_USER_WEB_PORT:-4002}:80"
     depends_on:
       - academy-backend
-    restart: unless-stopped
+    restart: "no"  # SUSPENDED — hopenvision 통합 후 단독 운영 중단 (2026-04-28)
     profiles:
       - all
       - frontend
@@ -106,7 +118,7 @@ services:
       - "${ACADEMY_AGENT_PORT:-9011}:9011"
     extra_hosts:
       - "host.docker.internal:host-gateway"
-    restart: unless-stopped
+    restart: "no"  # SUSPENDED — hopenvision 통합 후 단독 운영 중단 (2026-04-28)
     profiles:
       - all
       - agent
@@ -118,7 +130,7 @@ services:
     command: ["redis-server", "--appendonly", "yes"]
     volumes:
       - academy_redis_data:/data
-    restart: unless-stopped
+    restart: "no"  # SUSPENDED — hopenvision 통합 후 단독 운영 중단 (2026-04-28)
     profiles:
       - all
       - backend


### PR DESCRIPTION
## Summary
- academy 가 hopenvision 통합 환경으로 흡수되어 단독 docker compose 운영 중단
- 파일은 단독 재개 가능성을 위해 보존, 자동 기동 경로(restart 정책 + CI push 트리거)는 모두 차단
- 운영 컨테이너 5개 stop+remove 완료, 이미지·볼륨은 보존

## Changes
- 모든 compose `restart` 정책: `unless-stopped`/`always` → `"no"` (서버/도커 재부팅에도 자동 기동 안 됨)
- 각 compose 헤더에 `[SUSPENDED]` 사유 + 단독 재개 절차 명시
- `.github/workflows/deploy-prod.yml`: `push:[prod]` 트리거 주석 처리, `workflow_dispatch` 수동 실행만 유지
- `README.md` 최상단에 SUSPENDED 안내 + 보존 자산 표 + 재개 절차 섹션 추가

## 보존 자산
- 이미지: `academy-academy-{backend,admin-web,user-web,agent}` (rebuild 없이 재기동 가능)
- 볼륨: `academy_academy_redis_data` (Redis 영속 데이터)

## Test plan
- [x] 운영 컨테이너 5개 stop + remove 확인 (`docker ps -a | grep academy` → none)
- [x] 이미지 4종 보존 확인
- [x] 볼륨 `academy_academy_redis_data` 보존 확인
- [x] 각 compose 의 `restart: "no"` 적용 확인
- [x] `deploy-prod.yml` push 트리거 비활성, workflow_dispatch 만 활성 확인

⚠️ 이 PR merge 후 prod 브랜치로 FF 승격해도 자동 deploy 는 발생하지 않습니다 (push 트리거 비활성화가 이번 PR 의 주 목적).

🤖 Generated with [Claude Code](https://claude.com/claude-code)